### PR TITLE
Update django-yaml-redirects

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ django-static-root-finder==0.1
 django-asset-server-url==0.1
 django-template-finder-view==0.2
 django-unslashed==0.3.0
-django-yaml-redirects==0.4
+django-yaml-redirects==0.5.4


### PR DESCRIPTION
This update fixes errors occuring from the empty (or with comments) redirects.yaml file
## QA

Run and try to access a page. You should not get an error.
