### PR TITLE
Summary page functionality

### DIFF
--- a/templates/includes/base_markdown.html
+++ b/templates/includes/base_markdown.html
@@ -5,7 +5,10 @@
 {% block main_content %}
 <div class="row u-no-padding--left">
 
-    {% include markdown_path %}
+    {% block inner_content %}
+        {% include markdown_path %}
+        {% block after_markdown %}{% endblock %}
+    {% endblock %}
 
 </div>
 {% endblock main_content %}

--- a/templates/includes/components/page_cards.html
+++ b/templates/includes/components/page_cards.html
@@ -1,0 +1,8 @@
+<ul>
+    {% for page in pages %}
+        <li>
+            <a href="{{ page.path }}">{{ page.title }}</a>
+            <p>{{ page.description }}</p>
+        </li>
+    {% endfor %}
+</ul>

--- a/templates/includes/markdown_page_types/summary.html
+++ b/templates/includes/markdown_page_types/summary.html
@@ -1,0 +1,7 @@
+{% extends 'includes/base_markdown.html' %}
+
+{% block after_markdown %}
+
+=== Summary page ===
+
+{% endblock %}

--- a/templates/includes/markdown_page_types/summary.html
+++ b/templates/includes/markdown_page_types/summary.html
@@ -4,6 +4,8 @@
 
 {{ block.super }}
 
-=== Summary page ===
+<h2>Pages</h2>
+
+{% page_cards summary_pages %}
 
 {% endblock %}

--- a/templates/includes/markdown_page_types/summary.html
+++ b/templates/includes/markdown_page_types/summary.html
@@ -1,6 +1,8 @@
-{% extends 'includes/base_markdown.html' %}
+{% extends base_template %}
 
-{% block after_markdown %}
+{% block inner_content %}
+
+{{ block.super }}
 
 === Summary page ===
 

--- a/templates/pages/core/index.md
+++ b/templates/pages/core/index.md
@@ -1,3 +1,7 @@
+----
+title: Core
+page_type: summary
+----
 # Core
 
 Hello!

--- a/templates/pages/core/index.md
+++ b/templates/pages/core/index.md
@@ -1,9 +1,12 @@
 ----
 title: Core
+description: Core summary page
 page_type: summary
+summary_pages:
+    - reference/example-topic
+    - /core/reference/example-topic
 ----
+
 # Core
 
-Hello!
-
-[Example topic](/core/reference/example-topic)
+Core summary introduction

--- a/templates/pages/core/reference/example-topic.md
+++ b/templates/pages/core/reference/example-topic.md
@@ -1,7 +1,6 @@
 ---
-title: A topic title
+title: Example topic
 description: A genuine honest-to-god topic
 ---
 
 This is some topic content.
-

--- a/webapp/lib/markdown.py
+++ b/webapp/lib/markdown.py
@@ -1,0 +1,40 @@
+import frontmatter
+from django.conf import settings
+from django.template import loader
+
+
+def parse_frontmatter(markdown_content):
+    metadata = {}
+    try:
+        file_parts = frontmatter.loads(markdown_content)
+        metadata = file_parts.metadata
+    except (ScannerError, ParserError):
+        """
+        If there's a parsererror, it's because frontmatter had to parse
+        the entire file (not finding frontmatter at the top)
+        and encountered an unexpected format somewhere in it.
+        This means the file has no frontmatter, so we can simply continue.
+        """
+        pass
+    return metadata
+
+
+def get_page_data(pages, root_path=None):
+    template_root = ''.join([
+        getattr(settings, 'TEMPLATE_FINDER_PATH', ''), '/'
+    ])
+
+    page_data = []
+    for path in pages:
+        # If trying to lookup relative path
+        if root_path and not path.startswith('/'):
+            path = '/'.join([root_path, path])
+
+        template_path = ''.join([template_root, path, '.md'])
+        template = loader.get_template(template_path)
+        with open(template.origin.name, 'r') as f:
+            metadata = parse_frontmatter(f.read())
+            metadata['path'] = path
+            page_data.append(metadata)
+
+    return page_data

--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -45,8 +45,9 @@ ASSET_SERVER_URL = 'https://assets.ubuntu.com/v1/'
 
 # See https://docs.djangoproject.com/en/dev/ref/contrib/
 INSTALLED_APPS = [
+    'webapp',
     'django.contrib.staticfiles',
-    'django_versioned_static_url'
+    'django_versioned_static_url',
 ]
 
 MIDDLEWARE_CLASSES = [
@@ -62,7 +63,11 @@ TEMPLATES = [
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
         'DIRS': [os.path.join(BASE_DIR, 'templates')],
         'OPTIONS': {
+            'builtins': [
+                'webapp.templatetags',
+            ],
             'context_processors': [
+                'django.template.context_processors.request',
                 'django_asset_server_url.asset_server_url',
             ],
             'loaders': [

--- a/webapp/templatetags.py
+++ b/webapp/templatetags.py
@@ -1,0 +1,16 @@
+from django import template
+
+from webapp.lib.markdown import get_page_data
+
+register = template.Library()
+
+
+@register.inclusion_tag(
+    'includes/components/page_cards.html', takes_context=True
+)
+def page_cards(context, pages):
+    request = context['request']
+    page_data = get_page_data(pages, request.path)
+    return {
+        'pages': page_data,
+    }

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -63,14 +63,22 @@ class MarkdownView(TemplateView):
 
         return template, template_path if template else None
 
+    def _get_page_type_path(self, page_type):
+        return 'includes/markdown_page_types/{0}.html'.format(page_type)
+
     def get_context_data(self, **kwargs):
         path = self.kwargs['path']
         template, template_path = self._find_template(path)
         with open(template.origin.name, 'r') as f:
             metadata = self._parse_frontmatter(f.read())
 
+        page_type = metadata.get('page_type')
+        page_type_path = None
+        if page_type:
+            page_type_path = self._get_page_type_path(page_type)
+
         # Override the template if it is set in frontmatter
-        self.template_override = metadata.get('template', '')
+        self.template_override = metadata.get('template') or page_type_path
 
         context = super(MarkdownView, self).get_context_data(**kwargs)
         # We want to preserve context keys. So we need to it backwards and flip
@@ -79,4 +87,5 @@ class MarkdownView(TemplateView):
         # More specific overrides and defaults.
         context['title'] = metadata.get('title', '')
         context['markdown_path'] = template_path
+        context['page_type'] = page_type
         return context


### PR DESCRIPTION
Add page_type option for markdown pages to load specific template and functionality.
This is first set up for creating a summary page, which lists cards linking to pages. These cards pull data from the pages' frontmatter.

This is currently unstyled, and is just fhe core functionality.

# QA
Go to `/core` and check the cards are showing with the correct data, and linking to the correct page.