### PR TITLE
Temp global nav fix

### DIFF
--- a/static/sass/global.scss
+++ b/static/sass/global.scss
@@ -389,3 +389,14 @@ a:link:hover {
 .p-link--external:after {
   @include link-svg-icon($color: $color-brand);
 }
+
+// global nav overrides
+body.theme #nav-global .nav-global-wrapper {
+    width: $breakpoint-large !important;
+    display: none;
+    
+    @media only screen and (min-width: $breakpoint-medium) {
+      display: block;
+    }
+}
+


### PR DESCRIPTION
## Done

Override global nav to make breakpoint-large
Hide global nav on mobile until responsive solution implemented 

## QA

run ./run and make sure the global nav is the same width as primary nav
make sure the nav isn’t visible below breakpoint-medium
