### PR TITLE
remove right body on main row

### DIFF
--- a/templates/includes/base_markdown.html
+++ b/templates/includes/base_markdown.html
@@ -3,7 +3,7 @@
 {% block title %}{{ title }}{% endblock %}
 
 {% block main_content %}
-<div class="row u-no-padding--left">
+<div class="row u-no-padding--left u-no-padding--right">
 
     {% block inner_content %}
         {% include markdown_path %}


### PR DESCRIPTION
## Done

Remove right padding on base markdown template

## QA

Go to http://developer.ubuntu.com-master.demo.haus/ and resize ones browser to small and note that there is unequal padding on the container

Now then, if you ./run and head on over to http://127.0.0.1:8015/core for instance, you’ll see that the padding is equal

Bad
<img width="361" alt="bad" src="https://cloud.githubusercontent.com/assets/2152/20975164/7df10956-bc96-11e6-825d-69bf83700801.png">

Good
<img width="361" alt="good" src="https://cloud.githubusercontent.com/assets/2152/20975165/7e02d1b8-bc96-11e6-93b2-a897fb9a2fc5.png">