### PR TITLE
Markdown extensions and table of contents

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,7 @@ django-template-finder-view==0.3
 django-unslashed==0.3.0
 django-yaml-redirects==0.5.4
 markdown==2.6.7
+mdx-anchors-away==1.0.1
+mdx-callouts==1.0.0
+mdx-foldouts==1.0.0
 python-frontmatter==0.2.1

--- a/templates/includes/base_markdown.html
+++ b/templates/includes/base_markdown.html
@@ -6,7 +6,7 @@
 <div class="row u-no-padding--left">
 
     {% block inner_content %}
-        {% include markdown_path %}
+        {{ markdown|safe }}
         {% block after_markdown %}{% endblock %}
     {% endblock %}
 

--- a/templates/includes/markdown_page_types/documentation.html
+++ b/templates/includes/markdown_page_types/documentation.html
@@ -1,0 +1,15 @@
+{% extends base_template %}
+
+
+{% block main_content %}
+<div class="row u-no-padding--left">
+
+    {{ markdown|safe }}
+
+</div>
+
+{% if table_of_contents %}
+{{ table_of_contents|safe }}
+{% endif %}
+
+{% endblock main_content %}

--- a/templates/pages/core/get-started/index.md
+++ b/templates/pages/core/get-started/index.md
@@ -2,7 +2,7 @@
 title: Get started
 description: Your Ubuntu Core first steps, installing Ubuntu Core on your board or in a Virtual Machine.
 ---
-
+[TOC]
 # Get started
 
 Ubuntu Core is supported on a variety of chipsets, boards, SOCs and virtual machines, including Raspberry Pi 2 and 3, Qualcomm DragonBoard 410c, Intel NUC, Intel Joule, Samsung Artik and KVM.

--- a/templates/pages/core/get-started/index.md
+++ b/templates/pages/core/get-started/index.md
@@ -2,7 +2,7 @@
 title: Get started
 description: Your Ubuntu Core first steps, installing Ubuntu Core on your board or in a Virtual Machine.
 ---
-[TOC]
+
 # Get started
 
 Ubuntu Core is supported on a variety of chipsets, boards, SOCs and virtual machines, including Raspberry Pi 2 and 3, Qualcomm DragonBoard 410c, Intel NUC, Intel Joule, Samsung Artik and KVM.

--- a/webapp/lib/markdown.py
+++ b/webapp/lib/markdown.py
@@ -69,12 +69,15 @@ def get_page_data(pages, root_path=None):
         # We don't need any slashes at the ends
         path.strip('/')
 
+        template_paths = [
+            ''.join([template_root, path, '.md']),
+            ''.join([template_root, path, '/index.md']),
+        ]
         try:
-            template_path = ''.join([template_root, path, '.md'])
-            template = loader.get_template(template_path)
+            template = loader.select_template(template_paths)
+            template_path = template.origin.name
         except TemplateDoesNotExist:
-            template_path = ''.join([template_root, path, '/index.md'])
-            template = loader.get_template(template_path)
+            raise Exception("Can't find template metadata for: %s" % path)
 
         with open(template.origin.name, 'r') as f:
             metadata = parse_frontmatter(f.read())

--- a/webapp/lib/markdown.py
+++ b/webapp/lib/markdown.py
@@ -1,7 +1,24 @@
+from __future__ import absolute_import
+
 import frontmatter
+import markdown as _markdown
+
 from django.conf import settings
 from django.template import loader
 from django.template import TemplateDoesNotExist
+
+
+markdown_extensions = [
+    'markdown.extensions.attr_list',
+    'markdown.extensions.def_list',
+    'markdown.extensions.fenced_code',
+    'markdown.extensions.meta',
+    'markdown.extensions.tables',
+    'markdown.extensions.toc',
+    'mdx_callouts',
+    'mdx_anchors_away',
+    'mdx_foldouts',
+]
 
 
 def parse_frontmatter(markdown_content):
@@ -18,6 +35,25 @@ def parse_frontmatter(markdown_content):
         """
         pass
     return metadata
+
+
+def parse_markdown(markdown_content):
+    metadata = {}
+    try:
+        file_parts = frontmatter.loads(markdown_content)
+        metadata = file_parts.metadata
+        markdown_content = file_parts.content
+    except (ScannerError, ParserError):
+        """
+        If there's a parsererror, it's because frontmatter had to parse
+        the entire file (not finding frontmatter at the top)
+        and encountered an unexpected format somewhere in it.
+        This means the file has no frontmatter, so we can simply continue.
+        """
+        pass
+
+    markdown_parser = _markdown.Markdown(extensions=markdown_extensions)
+    return markdown_parser.convert(markdown_content)
 
 
 def get_page_data(pages, root_path=None):

--- a/webapp/lib/markdown.py
+++ b/webapp/lib/markdown.py
@@ -71,7 +71,6 @@ def get_page_data(pages, root_path=None):
 
         template_paths = [
             ''.join([template_root, path, '.md']),
-            ''.join([template_root, path, '/index.md']),
         ]
         try:
             template = loader.select_template(template_paths)

--- a/webapp/lib/markdown/__init__.py
+++ b/webapp/lib/markdown/__init__.py
@@ -1,0 +1,3 @@
+from __future__ import absolute_import
+
+from .markdown import *

--- a/webapp/lib/markdown/extensions/vanilla_toc.py
+++ b/webapp/lib/markdown/extensions/vanilla_toc.py
@@ -1,0 +1,43 @@
+from markdown.extensions.toc import *
+
+
+class VanillaTocTreeprocessor(TocTreeprocessor):
+    def build_toc_div(self, toc_list):
+        """ Return a string div given a toc list. """
+        div = etree.Element("div")
+        div.attrib["class"] = "p-toc"
+
+        # Add title to the div
+        if self.title:
+            header = etree.SubElement(div, "span")
+            header.attrib["class"] = "toctitle"
+            header.text = self.title
+
+        def build_etree_ul(toc_list, parent):
+            ul = etree.SubElement(parent, "ul")
+            ul.attrib['class'] = 'p-toc__list'
+            for item in toc_list:
+                # List item link, to be inserted into the toc div
+                li = etree.SubElement(ul, "li")
+                li.attrib['class'] = 'p-toc__item'
+                link = etree.SubElement(li, "a")
+                link.text = item.get('name', '')
+                link.attrib['class'] = 'p-toc__link'
+                link.attrib["href"] = '#' + item.get('id', '')
+                if item['children']:
+                    build_etree_ul(item['children'], li)
+            return ul
+
+        build_etree_ul(toc_list, div)
+        prettify = self.markdown.treeprocessors.get('prettify')
+        if prettify:
+            prettify.run(div)
+        return div
+
+
+class VanillaTocExtension(TocExtension):
+    TreeProcessorClass = VanillaTocTreeprocessor
+
+
+def makeExtension(*args, **kwargs):
+    return VanillaTocExtension(*args, **kwargs)

--- a/webapp/lib/markdown/markdown.py
+++ b/webapp/lib/markdown/markdown.py
@@ -39,7 +39,7 @@ def parse_frontmatter(markdown_content):
     return metadata
 
 
-def get_markdown_with_parser(markdown_content):
+def parse_markdown(markdown_content):
     metadata = {}
     try:
         file_parts = frontmatter.loads(markdown_content)
@@ -54,19 +54,11 @@ def get_markdown_with_parser(markdown_content):
         """
         pass
 
-
     markdown_parser = _markdown.Markdown(extensions=markdown_extensions)
     parsed_markdown = markdown_parser.convert(markdown_content)
     table_of_contents = markdown_parser.toc
     if table_of_contents:
         metadata['table_of_contents'] = table_of_contents
-    return markdown_parser, parsed_markdown, metadata
-
-
-def parse_markdown(markdown_content):
-    parser, parsed_markdown, metadata = get_markdown_with_parser(
-        markdown_content
-    )
     return parsed_markdown, metadata
 
 

--- a/webapp/lib/markdown/markdown.py
+++ b/webapp/lib/markdown/markdown.py
@@ -14,10 +14,10 @@ markdown_extensions = [
     'markdown.extensions.fenced_code',
     'markdown.extensions.meta',
     'markdown.extensions.tables',
-    'markdown.extensions.toc',
     'mdx_callouts',
     'mdx_anchors_away',
     'mdx_foldouts',
+    'webapp.lib.markdown.extensions.vanilla_toc',
 ]
 
 

--- a/webapp/lib/markdown/markdown.py
+++ b/webapp/lib/markdown/markdown.py
@@ -7,6 +7,10 @@ from django.conf import settings
 from django.template import loader
 from django.template import TemplateDoesNotExist
 
+from .extensions.vanilla_toc import VanillaTocExtension
+
+from markdown.extensions.toc import TocExtension
+
 
 markdown_extensions = [
     'markdown.extensions.attr_list',
@@ -17,7 +21,7 @@ markdown_extensions = [
     'mdx_callouts',
     'mdx_anchors_away',
     'mdx_foldouts',
-    'webapp.lib.markdown.extensions.vanilla_toc',
+    TocExtension(),
 ]
 
 
@@ -53,6 +57,8 @@ def parse_markdown(markdown_content):
         pass
 
     markdown_parser = _markdown.Markdown(extensions=markdown_extensions)
+    for test in markdown_parser.toc:
+        print(test)
     return markdown_parser.convert(markdown_content)
 
 

--- a/webapp/lib/markdown/markdown.py
+++ b/webapp/lib/markdown/markdown.py
@@ -78,11 +78,7 @@ def get_page_data(pages, root_path=None):
         template_paths = [
             ''.join([template_root, path, '.md']),
         ]
-        try:
-            template = loader.select_template(template_paths)
-            template_path = template.origin.name
-        except TemplateDoesNotExist:
-            raise Exception("Can't find template metadata for: %s" % path)
+        template = loader.select_template(template_paths)
 
         with open(template.origin.name, 'r') as f:
             metadata = parse_frontmatter(f.read())

--- a/webapp/lib/markdown/markdown.py
+++ b/webapp/lib/markdown/markdown.py
@@ -9,8 +9,6 @@ from django.template import TemplateDoesNotExist
 
 from .extensions.vanilla_toc import VanillaTocExtension
 
-from markdown.extensions.toc import TocExtension
-
 
 markdown_extensions = [
     'markdown.extensions.attr_list',
@@ -21,7 +19,7 @@ markdown_extensions = [
     'mdx_callouts',
     'mdx_anchors_away',
     'mdx_foldouts',
-    TocExtension(),
+    VanillaTocExtension(marker=''),
 ]
 
 
@@ -41,7 +39,7 @@ def parse_frontmatter(markdown_content):
     return metadata
 
 
-def parse_markdown(markdown_content):
+def get_markdown_with_parser(markdown_content):
     metadata = {}
     try:
         file_parts = frontmatter.loads(markdown_content)
@@ -56,10 +54,20 @@ def parse_markdown(markdown_content):
         """
         pass
 
+
     markdown_parser = _markdown.Markdown(extensions=markdown_extensions)
-    for test in markdown_parser.toc:
-        print(test)
-    return markdown_parser.convert(markdown_content)
+    parsed_markdown = markdown_parser.convert(markdown_content)
+    table_of_contents = markdown_parser.toc
+    if table_of_contents:
+        metadata['table_of_contents'] = table_of_contents
+    return markdown_parser, parsed_markdown, metadata
+
+
+def parse_markdown(markdown_content):
+    parser, parsed_markdown, metadata = get_markdown_with_parser(
+        markdown_content
+    )
+    return parsed_markdown, metadata
 
 
 def get_page_data(pages, root_path=None):

--- a/webapp/lib/markdown/markdown.py
+++ b/webapp/lib/markdown/markdown.py
@@ -5,7 +5,8 @@ import markdown as _markdown
 
 from django.conf import settings
 from django.template import loader
-from django.template import TemplateDoesNotExist
+from yaml.scanner import ScannerError
+from yaml.parser import ParserError
 
 from .extensions.vanilla_toc import VanillaTocExtension
 

--- a/webapp/loaders.py
+++ b/webapp/loaders.py
@@ -52,13 +52,20 @@ class MarkdownLoader(Loader):
         raise TemplateDoesNotExist(name)
 
     def load_template_source(self, template_name, template_dirs=None):
+        template_name_parts = template_name.split('.md')
+        template_name_index = ''.join([template_name_parts[0], '/index.md'])
+        template_names = [
+            template_name,
+            template_name_index,
+        ]
         for loader in self.loaders:
-            try:
-                return loader.load_template_source(
-                    template_name, template_dirs
-                )
-            except TemplateDoesNotExist:
-                pass
+            for template_name in template_names:
+                try:
+                    return loader.load_template_source(
+                        template_name, template_dirs
+                    )
+                except TemplateDoesNotExist:
+                    pass
         raise TemplateDoesNotExist(template_name)
 
     def load_template(self, template_name, template_dirs=None):

--- a/webapp/loaders.py
+++ b/webapp/loaders.py
@@ -104,6 +104,7 @@ class MarkdownLoader(Loader):
             template = Template(source, origin, template_name)
         except NotImplementedError:
             template, origin = self.find_template(template_name, template_dirs)
+        print(template)
         return template, origin
 
     def reset(self):

--- a/webapp/loaders.py
+++ b/webapp/loaders.py
@@ -52,6 +52,10 @@ class MarkdownLoader(Loader):
         raise TemplateDoesNotExist(name)
 
     def load_template_source(self, template_name, template_dirs=None):
+        """
+        Look for template through loaders, including checking if the source
+        is a folder with an index file.
+        """
         template_name_parts = template_name.split('.md')
         template_name_index = ''.join([template_name_parts[0], '/index.md'])
         template_names = [
@@ -94,7 +98,7 @@ class MarkdownLoader(Loader):
             source, display_name = self.load_template_source(
                 template_name, template_dirs
             )
-            source = parse_markdown(source)
+            source, metadata = parse_markdown(source)
             origin = make_origin(
                 display_name,
                 self.load_template_source,
@@ -104,7 +108,7 @@ class MarkdownLoader(Loader):
             template = Template(source, origin, template_name)
         except NotImplementedError:
             template, origin = self.find_template(template_name, template_dirs)
-        print(template)
+
         return template, origin
 
     def reset(self):

--- a/webapp/loaders.py
+++ b/webapp/loaders.py
@@ -1,6 +1,4 @@
 import hashlib
-import frontmatter
-import markdown
 import os
 
 from django.conf import settings
@@ -12,6 +10,8 @@ from django.template.loaders.base import Loader
 from yaml.scanner import ScannerError
 from yaml.parser import ParserError
 
+from webapp.lib.markdown import parse_markdown
+
 find_template_loader = Engine.get_default().find_template_loader
 
 
@@ -21,25 +21,6 @@ def make_origin(display_name, loader, name, dirs):
         template_name=name,
         loader=loader,
     )
-
-
-def parse_markdown(markdown_content):
-    metadata = {}
-    try:
-        file_parts = frontmatter.loads(markdown_content)
-        metadata = file_parts.metadata
-        markdown_content = file_parts.content
-    except (ScannerError, ParserError):
-        """
-        If there's a parsererror, it's because frontmatter had to parse
-        the entire file (not finding frontmatter at the top)
-        and encountered an unexpected format somewhere in it.
-        This means the file has no frontmatter, so we can simply continue.
-        """
-        pass
-
-    markdown_parser = markdown.Markdown()
-    return markdown_parser.convert(markdown_content)
 
 
 class MarkdownLoader(Loader):

--- a/webapp/loaders.py
+++ b/webapp/loaders.py
@@ -7,8 +7,6 @@ from django.template.base import Template
 from django.template.engine import Engine
 from django.template.exceptions import TemplateDoesNotExist
 from django.template.loaders.base import Loader
-from yaml.scanner import ScannerError
-from yaml.parser import ParserError
 
 from webapp.lib.markdown import parse_markdown
 
@@ -82,11 +80,6 @@ class MarkdownLoader(Loader):
             template, origin = self._generate_template(
                 template_name, template_dirs
             )
-            if not hasattr(template, 'render'):
-                try:
-                    template = Template(source, origin, template_name)
-                except (TemplateDoesNotExist, UnboundLocalError):
-                    return template, origin
             self.template_cache[key] = template
         return self.template_cache[key], None
 
@@ -108,6 +101,12 @@ class MarkdownLoader(Loader):
             template = Template(source, origin, template_name)
         except NotImplementedError:
             template, origin = self.find_template(template_name, template_dirs)
+
+        if not hasattr(template, 'render'):
+            try:
+                template = Template(source, origin, template_name)
+            except (TemplateDoesNotExist, UnboundLocalError):
+                return template, origin
 
         return template, origin
 

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -6,9 +6,11 @@ from django.template import (
     RequestContext,
     TemplateDoesNotExist,
 )
+from django.template.engine import Engine
 from django.views.generic import TemplateView
 
 from webapp.lib.markdown import parse_frontmatter
+from webapp.loaders import MarkdownLoader
 
 
 def custom_404(request):
@@ -26,6 +28,7 @@ class MarkdownView(TemplateView):
     def __init__(self, *args, **kwargs):
         self.metadata = []
         self.page_type_template = None
+        self.markdown_loader = self._find_markdown_loader()
         return super(MarkdownView, self).__init__(*args, **kwargs)
 
     def get_template_names(self):
@@ -33,6 +36,13 @@ class MarkdownView(TemplateView):
 
     def _get_base_template_name(self):
         return self.template_name or self.kwargs['template_name']
+
+    def _find_markdown_loader(self):
+        loaders = Engine.get_default().template_loaders
+        for loader in loaders:
+            if isinstance(loader, MarkdownLoader):
+                return loader
+        raise Exception("Could not find MarkdownLoader")
 
     def _find_template(self, path):
         template_root = getattr(settings, 'TEMPLATE_FINDER_PATH', None)

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -9,8 +9,6 @@ from django.template import (
 from django.template.engine import Engine
 from django.views.generic import TemplateView
 
-from webapp.lib.markdown import parse_frontmatter
-# from webapp.lib.markdown import get_markdown_with_parser
 from webapp.lib.markdown import parse_markdown
 from webapp.loaders import MarkdownLoader
 
@@ -40,9 +38,9 @@ class MarkdownView(TemplateView):
 
     def _find_markdown_loader(self):
         loaders = Engine.get_default().template_loaders
-        for loader in loaders:
-            if isinstance(loader, MarkdownLoader):
-                return loader
+        for loader_instance in loaders:
+            if isinstance(loader_instance, MarkdownLoader):
+                return loader_instance
         raise Exception("Could not find MarkdownLoader")
 
     def _find_template_source(self, path):
@@ -52,7 +50,8 @@ class MarkdownView(TemplateView):
 
         template_path = ''.join([path, '.md'])
         try:
-            markdown, template_path = self.markdown_loader.load_template_source(
+            markdown_loader = self.markdown_loader
+            markdown, template_path = markdown_loader.load_template_source(
                 template_path
             )
         except TemplateDoesNotExist:
@@ -65,9 +64,7 @@ class MarkdownView(TemplateView):
 
     def _parse_markdown(self, path):
         markdown, template_path = self._find_template_source(path)
-        # parser, parsed_markdown, metadata = get_markdown_with_parser(markdown)
         parsed_markdown, metadata = parse_markdown(markdown)
-
 
         self.template_name = metadata.get('template')
         page_type = metadata.get('page_type')

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -10,6 +10,8 @@ from django.template.engine import Engine
 from django.views.generic import TemplateView
 
 from webapp.lib.markdown import parse_frontmatter
+# from webapp.lib.markdown import get_markdown_with_parser
+from webapp.lib.markdown import parse_markdown
 from webapp.loaders import MarkdownLoader
 
 
@@ -26,7 +28,6 @@ def custom_500(request):
 
 class MarkdownView(TemplateView):
     def __init__(self, *args, **kwargs):
-        self.metadata = []
         self.page_type_template = None
         self.markdown_loader = self._find_markdown_loader()
         return super(MarkdownView, self).__init__(*args, **kwargs)
@@ -44,43 +45,56 @@ class MarkdownView(TemplateView):
                 return loader
         raise Exception("Could not find MarkdownLoader")
 
-    def _find_template(self, path):
+    def _find_template_source(self, path):
         template_root = getattr(settings, 'TEMPLATE_FINDER_PATH', None)
         if template_root:
             path = ''.join([template_root, '/', path])
 
-        template_paths = [
-            ''.join([path, '.md']),
-        ]
+        template_path = ''.join([path, '.md'])
         try:
-            template = loader.select_template(template_paths)
-            template_path = template.origin.name
+            markdown, template_path = self.markdown_loader.load_template_source(
+                template_path
+            )
         except TemplateDoesNotExist:
             raise Http404("Can't find page for: %s" % path)
 
-        return template, template_path if template else None
+        return markdown, template_path
 
     def _get_page_type_template(self, page_type):
         return 'includes/markdown_page_types/{0}.html'.format(page_type)
 
-    def get_context_data(self, **kwargs):
-        request_path = self.kwargs['path']
-        template, template_path = self._find_template(request_path)
-        with open(template_path, 'r') as f:
-            metadata = parse_frontmatter(f.read())
+    def _parse_markdown(self, path):
+        markdown, template_path = self._find_template_source(path)
+        # parser, parsed_markdown, metadata = get_markdown_with_parser(markdown)
+        parsed_markdown, metadata = parse_markdown(markdown)
+
 
         self.template_name = metadata.get('template')
         page_type = metadata.get('page_type')
         if page_type:
             self.page_type_template = self._get_page_type_template(page_type)
 
+        return parsed_markdown, metadata
+
+    def get_context_data(self, markdown, metadata, **kwargs):
         context = super(MarkdownView, self).get_context_data(**kwargs)
         # We want to preserve context keys. So do it backwards and flip around
         metadata.update(context)
         context = metadata
         # More specific overrides and defaults.
         context['base_template'] = self._get_base_template_name()
-        context['markdown_path'] = template_path
-        context['page_type'] = page_type
+        context['markdown'] = markdown
+        context['page_type'] = metadata.get('page_type')
         context['title'] = metadata.get('title', '')
         return context
+
+    def get(self, request, *args, **kwargs):
+        request_path = self.kwargs['path']
+        markdown, metadata = self._parse_markdown(request_path)
+
+        context = self.get_context_data(
+            markdown=markdown,
+            metadata=metadata,
+            **kwargs
+        )
+        return self.render_to_response(context)

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -41,7 +41,6 @@ class MarkdownView(TemplateView):
 
         template_paths = [
             ''.join([path, '.md']),
-            ''.join([path, '/index.md']),
         ]
         try:
             template = loader.select_template(template_paths)


### PR DESCRIPTION
- Markdown extensions
- Anchor links
- Table of contents on documentation pages

This change moves direct view markdown parsing, into the view itself. The main reason is that it means the view can access the table of contents and display it on the page anywhere the template decides.

The TOC is added to the documentation page_type, and we will need to add this page_type to pages shortly. It needs a little more styling but the functionality works!