### PR TITLE
Add insights feed block for modular page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# App
+cache.sqlite
+
 # Python
 __pycache__/
 env/

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,12 @@ django-asset-server-url==0.1
 django-template-finder-view==0.3
 django-unslashed==0.3.0
 django-yaml-redirects==0.5.4
+feedparser==5.2.1
+lockfile==0.12.2
 markdown==2.6.7
 mdx-anchors-away==1.0.1
 mdx-callouts==1.0.0
 mdx-foldouts==1.0.0
 python-frontmatter==0.2.1
+requests==2.10.0
+requests-cache==0.4.12

--- a/templates/includes/components/feed_cards.html
+++ b/templates/includes/components/feed_cards.html
@@ -1,0 +1,14 @@
+{% get_rss_feed feed_url limit=limit as feed %}
+
+<h2>News</h2>
+
+<ul class="grid-list u-clearfix u-no-margin--left u-no-padding--left col-12">
+{% for item in feed %}
+    <li class="col-6 grid-list__item{% if forloop.last %} last-item{% endif %}{% cycle ' odd' ' even' %}">
+        <div class="col-12">
+            <h5><a href="{{ item.link }}">{{ item.title }}</a></h5>
+            <p><time pubdate datetime="{{ item.updated }}">{{ item.updated_datetime|date:"j F Y" }}</time></p>
+        </div>
+    </li>
+{% endfor %}
+</ul>

--- a/templates/includes/markdown_page_types/modular.html
+++ b/templates/includes/markdown_page_types/modular.html
@@ -1,3 +1,4 @@
+
 {% extends base_template %}
 
 {% block inner_content %}
@@ -5,5 +6,11 @@
 {{ block.super }}
 
 {% page_cards summary_pages %}
+
+{% if insights_feed %}
+    {% with "https://insights.ubuntu.com/feed?tag="|add:insights_feed.tag as feed_url %}
+    {% feed_cards feed_url limit=4 %}
+    {% endwith %}
+{% endif %}
 
 {% endblock %}

--- a/templates/pages/core/index.md
+++ b/templates/pages/core/index.md
@@ -8,6 +8,8 @@ summary_pages:
     - publish-and-distribute
     - documentation
     - troubleshooting
+insights_feed:
+    tag: core
 ----
 
 # Core

--- a/webapp/lib/feeds.py
+++ b/webapp/lib/feeds.py
@@ -1,0 +1,71 @@
+import feedparser
+import logging
+import json
+from datetime import datetime
+from requests.exceptions import Timeout
+from requests_cache import CachedSession
+from time import mktime
+
+from django.conf import settings
+
+
+logger = logging.getLogger(__name__)
+requests_timeout = getattr(settings, 'FEED_TIMEOUT', 60)
+expiry_seconds = getattr(settings, 'FEED_EXPIRY', 300)
+
+cached_request = CachedSession(
+    expire_after=expiry_seconds,
+)
+
+
+def get_json_feed_content(url, offset=0, limit=None):
+    """
+    Get the entries in a JSON feed
+    """
+
+    end = limit + offset if limit is not None else None
+
+    try:
+        response = cached_request.get(url, timeout=requests_timeout)
+        content = json.loads(response.text)
+    except Timeout as timeout_error:
+        logger.warning(
+            'Attempt to get feed timed out after {}. Message: {}'.format(
+                requests_timeout,
+                str(timeout_error)
+            )
+        )
+        content = []  # Empty response
+
+    return content[offset:end]
+
+
+def get_rss_feed_content(url, offset=0, limit=None, exclude_items_in=None):
+    """
+    Get the entries from an RSS feed
+    """
+
+    end = limit + offset if limit is not None else None
+
+    try:
+        response = cached_request.get(url, timeout=requests_timeout)
+        content = feedparser.parse(response.text).entries
+    except Timeout as timeout_error:
+        logger.warning(
+            'Attempt to get feed timed out after {}. Message: {}'.format(
+                requests_timeout,
+                str(timeout_error)
+            )
+        )
+        content = []  # Empty response
+
+    if exclude_items_in:
+        exclude_ids = [item['guid'] for item in exclude_items_in]
+        content = [item for item in content if item['guid'] not in exclude_ids]
+
+    content = content[offset:end]
+    for item in content:
+        updated_time = mktime(item['updated_parsed'])
+        item['updated_datetime'] = datetime.fromtimestamp(updated_time)
+
+    return content

--- a/webapp/templatetags.py
+++ b/webapp/templatetags.py
@@ -1,8 +1,28 @@
 from django import template
 
+from webapp.lib.feeds import get_json_feed_content, get_rss_feed_content
 from webapp.lib.markdown import get_page_data
 
 register = template.Library()
+
+
+@register.simple_tag
+def get_json_feed(feed_url, **kwargs):
+    return get_json_feed_content(feed_url, **kwargs)
+
+
+@register.simple_tag
+def get_rss_feed(feed_url, **kwargs):
+    return get_rss_feed_content(feed_url, **kwargs)
+
+
+@register.inclusion_tag(
+    'includes/components/feed_cards.html'
+)
+def feed_cards(feed_url, **kwargs):
+    context = kwargs
+    context['feed_url'] = feed_url
+    return context
 
 
 @register.inclusion_tag(


### PR DESCRIPTION
- Add a `feed_cards` template block
- Load this in modular template when config `insights_feed` is set, reading `insights_feed.tag`
- Set this up on `/core` page to pull in the core tag.
- Rough card styling