### PR TITLE
TOC: Update markup, method and add customisable title

### DIFF
--- a/templates/includes/markdown_page_types/documentation.html
+++ b/templates/includes/markdown_page_types/documentation.html
@@ -8,8 +8,47 @@
 
 </div>
 
-{% if table_of_contents %}
-{{ table_of_contents|safe }}
+{% if table_of_contents_items %}
+<aside class="p-aside" id="side-content">
+    <nav class="p-aside__section">
+        <h4 class="p-aside__header">{{ table_of_contents_title }}</h4>
+        <nav>
+            <ul class="p-toc">
+                {% for item in table_of_contents_items %}
+                <li class="p-toc__item"><a class="p-toc__link" href="#{{ item.id }}">{{ item.name }}</a></li>
+                {% endfor %}
+                <li class="p-toc__item" id="back-to-top" style="display: none"><a class="p-toc__link" href="#">Back to top</a></li>
+            </ul>
+         </nav>
+    </nav>
+</aside>
+
+<script>
+  /* Keep table of contents sticky and show "back-to-top" when scrolled */
+  var aside = document.querySelector('#side-content');
+  if (aside) {
+    var asideOffset = aside.offsetTop;
+    var asideWidth = aside.offsetWidth;
+    var backToTop = document.querySelector('#back-to-top');
+
+    window.addEventListener(
+      'scroll',
+      function(scrollEvent) {
+        var scrolled = window.innerWidth >= 768 && window.scrollY > asideOffset;
+
+        aside.classList.toggle('fixed', scrolled);
+
+        if (scrolled) {
+          aside.style.width = asideWidth + 'px';
+          backToTop.style.display = 'block';
+        } else {
+          aside.style.width = '';
+          backToTop.style.display = 'none';
+        }
+      }
+    );
+  }
+</script>
 {% endif %}
 
 {% endblock main_content %}

--- a/webapp/lib/markdown/markdown.py
+++ b/webapp/lib/markdown/markdown.py
@@ -47,10 +47,7 @@ def parse_markdown(markdown_content):
     markdown_content, metadata = parse_frontmatter(markdown_content)
     markdown_parser = _markdown.Markdown(extensions=markdown_extensions)
     parsed_markdown = markdown_parser.convert(markdown_content)
-    table_of_contents = markdown_parser.toc
-
-    if table_of_contents:
-        metadata['table_of_contents'] = table_of_contents
+    metadata['table_of_contents_items'] = markdown_parser.toc_items
 
     return parsed_markdown, metadata
 

--- a/webapp/lib/markdown/markdown.py
+++ b/webapp/lib/markdown/markdown.py
@@ -26,22 +26,7 @@ markdown_extensions = [
 
 def parse_frontmatter(markdown_content):
     metadata = {}
-    try:
-        file_parts = frontmatter.loads(markdown_content)
-        metadata = file_parts.metadata
-    except (ScannerError, ParserError):
-        """
-        If there's a parsererror, it's because frontmatter had to parse
-        the entire file (not finding frontmatter at the top)
-        and encountered an unexpected format somewhere in it.
-        This means the file has no frontmatter, so we can simply continue.
-        """
-        pass
-    return metadata
 
-
-def parse_markdown(markdown_content):
-    metadata = {}
     try:
         file_parts = frontmatter.loads(markdown_content)
         metadata = file_parts.metadata
@@ -55,11 +40,18 @@ def parse_markdown(markdown_content):
         """
         pass
 
+    return markdown_content, metadata
+
+
+def parse_markdown(markdown_content):
+    markdown_content, metadata = parse_frontmatter(markdown_content)
     markdown_parser = _markdown.Markdown(extensions=markdown_extensions)
     parsed_markdown = markdown_parser.convert(markdown_content)
     table_of_contents = markdown_parser.toc
+
     if table_of_contents:
         metadata['table_of_contents'] = table_of_contents
+
     return parsed_markdown, metadata
 
 
@@ -82,7 +74,7 @@ def get_page_data(pages, root_path=None):
         template = loader.select_template(template_paths)
 
         with open(template.origin.name, 'r') as f:
-            metadata = parse_frontmatter(f.read())
+            markdown_content, metadata = parse_frontmatter(f.read())
             metadata['path'] = path
             page_data.append(metadata)
 

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -75,13 +75,19 @@ class MarkdownView(TemplateView):
 
     def get_context_data(self, markdown, metadata, **kwargs):
         context = super(MarkdownView, self).get_context_data(**kwargs)
+
         # We want to preserve context keys. So do it backwards and flip around
         metadata.update(context)
         context = metadata
+
         # More specific overrides and defaults.
         context['base_template'] = self._get_base_template_name()
         context['markdown'] = markdown
         context['page_type'] = metadata.get('page_type')
+        context['table_of_contents_title'] = metadata.get(
+            'table_of_contents_title',
+            'In this page'
+        )
         context['title'] = metadata.get('title', '')
         return context
 


### PR DESCRIPTION
- Change markdown plugin to only extract h2s
- Change plugin to output a list of item objects, rather than HTML
- Build up the HTML in the template, using new docs-vanilla-theme v1.2.0 format
- Add JavaScript to add "fixed" class when the page scrolls, and show/hide "Back to top" link
- Read "table_of_contents_title" property from frontmatter, or default to "In this page"

QA
--

First, edit `templates/pages/core/tutorials.md` and add `page_type: documentation` to the frontmatter.

```
./run
```

Visit <http://127.0.0.1:8015/core/tutorials> and check the table of contents markup is added to the bottom of the page (styling is expected to the broken / non-existent).