### PR TITLE
Fix markdown includes by rendering markdown as a template

### DIFF
--- a/templates/includes/base_markdown.html
+++ b/templates/includes/base_markdown.html
@@ -6,7 +6,7 @@
 <div class="row u-no-padding--left u-no-padding--right">
 
     {% block inner_content %}
-        {% block markdown %}{{ markdown|safe }}{% endblock %}
+        {% block markdown %}{% endblock %}
         {% block after_markdown %}{% endblock %}
     {% endblock %}
 

--- a/templates/includes/base_markdown.html
+++ b/templates/includes/base_markdown.html
@@ -6,7 +6,7 @@
 <div class="row u-no-padding--left u-no-padding--right">
 
     {% block inner_content %}
-        {{ markdown|safe }}
+        {% block markdown %}{{ markdown|safe }}{% endblock %}
         {% block after_markdown %}{% endblock %}
     {% endblock %}
 

--- a/templates/includes/markdown_page_types/documentation.html
+++ b/templates/includes/markdown_page_types/documentation.html
@@ -4,7 +4,7 @@
 {% block main_content %}
 <div class="row u-no-padding--left">
 
-    {{ markdown|safe }}
+    {% block markdown %}{% endblock %}
 
 </div>
 


### PR DESCRIPTION
Rather than echo out markdown on the page, put it into a Template object.
This allows the Django template parser to run through the markdown and perform actions on it as needed. In this case, it is fixing the includes blocks for the get-started pages.