### PR TITLE
Add search

### DIFF
--- a/templates/pages/search.html
+++ b/templates/pages/search.html
@@ -1,0 +1,96 @@
+{% extends 'includes/base.html' %}
+
+{% block title %}Search{% endblock %}
+
+{% block main_content %}
+<div class="row row-hero no-border search-container">
+    <div class="strip-inner-wrapper">
+    {% if query %}
+    {% if results %}
+    <h1>We've found {% if total %}{{ total }} {% endif %}results for "{{query}}"</h1>
+    {% else %}
+    <h1>Sorry we couldn't find "{{ query }}"</h1>
+    {% endif %}
+    {% else %}
+    <h1>Search Ubuntu and Canonical sites</h1>
+    {% endif %}
+
+    <form action="/search">
+        <fieldset class="main-search">
+            <label for="search-input" class="off-left">Search</label>
+            <input name="q" id="search-input" type="search" value="{{ query }}" placeholder="e.g. juju" />
+            <button type="submit"><img src="{{ ASSET_SERVER_URL }}19750a6d-search-black.svg" alt="search" /></button>
+        </fieldset>
+    </form>
+
+{% if query %}
+{% if request_succeeded %}
+{% if parse_succeeded %}
+{% if results %}
+    <section id="search-results" class="no-margin-bottom list list-spaced">
+        <p class="result-line results-top">Results{% if start or end %} {{ start }} to {{ end }}{% endif %}</p>
+{% for result in results %}
+        <article class="search-result twelve-col">
+            <h1>
+                <a href="{{ result.url }}" class="title-main">{{ result.title|safe }}</a>
+                <small class="result-url"><a href="{{ result.url }}">{{ result.url }}</a></small>
+            </h1>
+            <p>{{ result.summary|safe }}</p>
+        </article>
+{% endfor %}
+
+{% if start or end %}
+        <p class="bottom-results-total result-line">Results {{ start }} to {{ end }}</p>
+{% endif %}
+    </section>
+{% else %}
+    <h2>Why not try widening your search? You can do this by:</h2>
+    <ul>
+        <li>Adding alternative words or phrases</li>
+        <li>Using individual words instead of phrases</li>
+        <li>Trying a different spelling</li>
+    </ul>
+
+    <h2>Still no luck?</h2>
+
+    <ul>
+        <li><a href="/">Visit the Ubuntu homepage</a></li>
+        <li><a href="/contact-us">Contact us</a></li>
+    </ul>
+{% endif %} {# results #}
+
+{% if nav_items %}
+    <nav class="bottom-nav clear" id="page-nav">
+        <ul class="nav-forward">
+{% for item in nav_items %}
+{% if item.direction == 'forward' %}
+            <li class="{{ item.class }}"><a href="{{ item.url }}">{{ item.name }}</a></li>
+{% endif %}
+{% endfor %}
+        </ul>
+
+        <ul class="nav-back">
+{% for item in nav_items %}
+{% if item.direction == 'back' %}
+            <li class="{{ item.class }}"><a href="{{ item.url }}">{{ item.name }}</a></li>
+{% endif %}
+{% endfor %}
+        </ul>
+    </nav>
+{% endif %} {# nav_items #}
+
+{% else %} {# parse_succeeded false #}
+    <label for="search-input" role="error" class="error-notification">
+        Failed to parse results. If you have time, please <a href="https://github.com/ubuntudesign/www.ubuntu.com/issues/new">file a bug</a>.
+    </label>
+{% endif %}
+{% else %} {# request_succeeded false #}
+    <label for="search-input" role="error" class="error-notification">
+        Failed to retrieve search results. If you have time, please <a href="https://github.com/ubuntudesign/www.ubuntu.com/issues/new">file a bug</a>.
+    </label>
+{% endif %} {# request_succeeded #}
+
+{% endif %} {# query #}
+    </div>
+</div>
+{% endblock main_content %}

--- a/webapp/lib/gsa.py
+++ b/webapp/lib/gsa.py
@@ -1,0 +1,120 @@
+import requests
+
+
+class GSAParser:
+    """
+    Query the Google Search Appliance
+    for results in JSON format
+    and fix the results in various ways
+    before returning them as a data object
+
+    Usage:
+
+    search_parser = GSAParser(domain="gsa.example.com")
+    results = search_parser.fixed_results(query="hello world")
+    """
+
+    domain = ""
+    client = ""
+    default_collection = ""
+    stylesheet = ""
+
+    def __init__(
+        self, domain,
+        client="default_frontend",
+        site_collection="default_collection",
+        stylesheet="json_frontend"
+    ):
+        self.domain = domain
+        self.client = client
+        self.site_collection = site_collection
+        self.stylesheet = stylesheet
+
+    def fixed_results(self, query, start=0, num=10):
+        """
+        Return a data object of results from the GSA,
+        fixed to show the correct total and avoid errors:
+        {
+            "query": <GSA's generated query>,
+            "results": [
+                {
+                    "url": ..,
+                    "title": ..,
+                    "summary": ..,
+                    "meta_tags" : [..],
+                    "size": ..
+                }, ..
+            ],
+            "results_nav": {
+                "total_results": <total - fixed to be accurate>,
+                "results_start": ..,
+                "results_end": ..,
+                "current_view": ..,
+                "have_prev": "1", # may exist
+                "have_next": "1", # may exist
+            }
+        }
+        """
+
+        results_data = self.results(query, start, num)
+        results_data["results_nav"]["total_results"] = self.total_results(query)
+
+        return results_data
+
+    def total_results(self, query):
+        """
+        Inexplicably, the GSA returns a completely incorrect total
+        This is a hack to get the correct total.
+
+        If you request with start>1000, the GSA returns nothing.
+        But if you request with start = 990, it returns the last page
+        even if there are only 10 results.
+
+        Therefore this is the way to get the real total
+        """
+
+        last_results = self.results(query, start=990, num=10)
+
+        return last_results["results_nav"]["results_end"]
+
+    def results(self, query, start, num):
+        """
+        GSA often returns invalid JSON - attempt to fix it
+        """
+
+        results_json = self.results_json(query, start, num)
+
+        return results_json
+
+    def results_json(self, query, start, num):
+        """
+        Query the GSA to get response in JSON format
+        and return it
+
+        Throws a URLError exception if it fails to
+        communicate with the GSA
+        """
+
+        # Query mustn't have spaces - or BREAKZ!
+        query = query.replace(' ', '+')
+
+        # Build the GSA URL
+        search_url_template = (
+            'http://{domain}/search'
+            '?q={q}&num={num}&start={start}&client={client}'
+            '&site={site}&output=xml_no_dtd'
+            '&proxystylesheet={stylesheet}'
+        )
+        search_url = search_url_template.format(
+            domain=self.domain,
+            q=query,
+            num=str(num),
+            start=str(start),
+            client=self.client,
+            site=self.site_collection,
+            stylesheet=self.stylesheet
+        )
+
+        response = requests.get(search_url)
+
+        return response.json()

--- a/webapp/search.example
+++ b/webapp/search.example
@@ -1,0 +1,158 @@
+
+{
+        
+"query": "ubuntu (site:www.ubuntu.com | site:www.canonical.com | site:help.ubuntu.com | site:insights.ubuntu.com )",
+"results": [
+    
+      {
+        "url": "http://www.ubuntu.com/",
+        "title": "The leading operating system for PCs, tablets, phones, IoT <b>...</b>",
+        "summary": "<b>Ubuntu</b> is an open source software platform that runs everywhere from IoT<br> devices, the smartphone, the tablet and the PC to the server and the <b>...</b>  ",
+        "meta_tags" : [
+    
+         ]
+    
+        ,
+        "size": "34k"
+      }
+    
+        ,
+      
+      {
+        "url": "https://www.ubuntu.com/about/about-ubuntu",
+        "title": "About <b>Ubuntu</b> | <b>Ubuntu</b>",
+        "summary": "<b>Ubuntu</b> is an open source software platform that runs everywhere from IoT<br> devices, the smartphone, the tablet and the PC to the server and the <b>...</b>  ",
+        "meta_tags" : [
+    
+         ]
+    
+        ,
+        "size": "29k"
+      }
+    
+        ,
+      
+      {
+        "url": "http://insights.ubuntu.com/",
+        "title": "<b>Ubuntu</b> Insights",
+        "summary": "<b>...</b> Search: <b>Ubuntu</b> Insights. Your <b>...</b> Taking a stand against unofficial <b>Ubuntu</b><br> images. By Canonical on 1 December 2016. <b>Ubuntu</b> <b>...</b>  ",
+        "meta_tags" : [
+    
+         ]
+    
+        ,
+        "size": "37k"
+      }
+    
+        ,
+      
+      {
+        "url": "https://www.ubuntu.com/about/canonical-and-ubuntu",
+        "title": "Canonical and <b>Ubuntu</b> | <b>Ubuntu</b>",
+        "summary": "<b>Ubuntu</b> is an open source software platform that runs everywhere from IoT<br> devices, the smartphone, the tablet and the PC to the server and the <b>...</b>  ",
+        "meta_tags" : [
+    
+         ]
+    
+        ,
+        "size": "26k"
+      }
+    
+        ,
+      
+      {
+        "url": "https://www.ubuntu.com/management/ubuntu-advantage",
+        "title": "Plans and pricing | Support | <b>Ubuntu</b>",
+        "summary": "Both options are part of the <b>Ubuntu</b> Advantage service package, however you<br> can try Landscape for free for 30 days, without committing to a <b>...</b>  ",
+        "meta_tags" : [
+    
+         ]
+    
+        ,
+        "size": "46k"
+      }
+    
+        ,
+      
+      {
+        "url": "http://www.ubuntu.com/cloud",
+        "title": "<b>Ubuntu</b> in the cloud | Cloud | <b>Ubuntu</b>",
+        "summary": "Whether you&#39;re building your own OpenStack cloud, want a hosted private<br> cloud or want to use <b>Ubuntu</b> in the public cloud, we offer all the training <b>...</b>  ",
+        "meta_tags" : [
+    
+         ]
+    
+        ,
+        "size": "53k"
+      }
+    
+        ,
+      
+      {
+        "url": "https://www.ubuntu.com/download/ubuntu-flavours",
+        "title": "<b>Ubuntu</b> flavours | <b>Ubuntu</b>",
+        "summary": "<b>Ubuntu</b> flavours offer a unique way to experience <b>Ubuntu</b>, each with their own<br> choice of default applications and settings, backed by the full <b>Ubuntu</b> <b>...</b>  ",
+        "meta_tags" : [
+    
+         ]
+    
+        ,
+        "size": "32k"
+      }
+    
+        ,
+      
+      {
+        "url": "https://www.ubuntu.com/desktop/ubuntu-kylin",
+        "title": "<b>Ubuntu</b> Kylin | <b>Ubuntu</b>",
+        "summary": "<b>Ubuntu</b> Kylin is a Chinese flavour of <b>Ubuntu</b>. Canonical partnered<br> with CSIP and NUDT to produce a fully localised and <b>...</b>  ",
+        "meta_tags" : [
+    
+         ]
+    
+        ,
+        "size": "36k"
+      }
+    
+        ,
+      
+      {
+        "url": "http://www.ubuntu.com/things",
+        "title": "<b>Ubuntu</b> for the Internet of Things | <b>Ubuntu</b>",
+        "summary": "From home control to drones, robots and industrial systems, <b>Ubuntu</b> Core<br> provides robust security, app stores and reliable updates for all your IoT <b>...</b>  ",
+        "meta_tags" : [
+    
+         ]
+    
+        ,
+        "size": "39k"
+      }
+    
+        ,
+      
+      {
+        "url": "https://www.ubuntu.com/download/ubuntu-kylin",
+        "title": "Download <b>Ubuntu</b> Kylin | Download | <b>Ubuntu</b>",
+        "summary": "<b>Ubuntu</b> is an open source software platform that runs everywhere from IoT<br> devices, the smartphone, the tablet and the PC to the server and the <b>...</b>  ",
+        "meta_tags" : [
+    
+         ]
+    
+        ,
+        "size": "29k"
+      }
+    
+],
+    
+      "results_nav": {
+      "total_results": "1290",
+      "results_start": "1",
+      "results_end": "10",
+      "current_view": "0"
+        ,
+        "have_next": "1"
+      
+      }
+    
+          }
+        

--- a/webapp/urls.py
+++ b/webapp/urls.py
@@ -4,7 +4,7 @@ from django_yaml_redirects import load_redirects
 from django_template_finder_view import TemplateFinder
 
 # Local
-from webapp.views import custom_404, custom_500, MarkdownView
+from webapp.views import custom_404, custom_500, MarkdownView, SearchView
 
 # Match any redirects first
 urlpatterns = load_redirects()
@@ -13,6 +13,7 @@ default_markdown_template = 'includes/base_markdown.html'
 
 # Try to find templates
 urlpatterns += [
+    url(r'^search/?$', SearchView.as_view()),
     url(
         r'^(?P<path>core(/.*)?)$',
         MarkdownView.as_view(),

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -1,3 +1,12 @@
+# Core modules
+import json
+import os
+try:
+    from urllib.error import URLError
+except ImportError:
+    from urllib2 import URLError
+
+# Third party modules
 from django.conf import settings
 from django.http import HttpResponseNotFound, HttpResponseServerError, Http404
 from django.template import (
@@ -9,7 +18,9 @@ from django.template import (
 from django.template.engine import Engine
 from django.views.generic import TemplateView
 
+# Local modules
 from webapp.lib.markdown import parse_markdown
+from webapp.lib.gsa import GSAParser
 from webapp.loaders import MarkdownLoader
 
 
@@ -95,3 +106,182 @@ class MarkdownView(TemplateView):
             **kwargs
         )
         return self.render_to_response(context)
+
+
+class SearchView(TemplateView):
+    '''
+    Return search results from the Google Search Appliance
+
+    Requests should be formatted: <url>?q=<string>&offset=<num>&limit=<num>
+
+    I've used "offset" and "limit" for pagination,
+    following the "Web API Design" standard:
+    https://pages.apigee.com/web-api-design-ebook.html
+
+    This gets results from Canonical's Google Search Appliance,
+    currently located at: butlerov.internal (10.22.112.8)
+    '''
+
+    template_name = "pages/search.html"
+
+    def get_context_data(self, **kwargs):
+        """
+        Extend CMSPageView.get_context_data to parse query parameters
+        and return search results from the Google Search Appliance (GSA)
+
+        E.g.: http://example.com/search?q=juju&limit=10&offset=10
+
+        Query parameters:
+        - q: the search query to be passed to the GSA
+        - limit: number of results to return, "page size" (default: 10)
+        - offset: where to start results at (default: 0)
+        """
+
+        # On live the GSA domain will be butlerov.internal
+        # but on dev, we need to access GSA through localhost
+        # (see GSASearchView docstring above)
+        gsa_domain = 'butlerov.internal'
+
+        parser = GSAParser(gsa_domain)
+
+        # Import context from parent
+        context = super(SearchView, self).get_context_data(**kwargs)
+
+        # defaults + GET params
+        context.update({
+            'query': self.request.GET.get('q', ''),
+            'results': [],
+            'request_succeeded': True,
+            'parse_succeeded': True,
+            'start': 0,
+            'end': 0,
+            'limit': int(self.request.GET.get('limit', '10')),
+            'offset': int(self.request.GET.get('offset', '0')),
+            'total': 0,
+            'nav_items': []
+        })
+
+        # return self.context
+        try:
+            if getattr(settings, 'DEBUG', False):
+                # Use a local file
+                example_filepath = os.path.join(
+                    os.path.dirname(__file__),
+                    'search.example'
+                )
+
+                with open(example_filepath) as example_file:
+                    gsa_results = json.load(example_file)
+            else:
+                gsa_results = parser.fixed_results(
+                    context['query'],
+                    start=context['offset'],
+                    num=context['limit']
+                )
+
+            nav_url = "{path}?q={query}".format(
+                path=self.request.path,
+                query=context['query']
+            )
+
+            results = self.parse_gsa_results(gsa_results)
+            context.update(results)
+
+            context['nav_items'] = self.build_nav_items(
+                context,
+                nav_url
+            )
+
+        except URLError:
+            context['request_succeeded'] = False
+        except ValueError:
+            context['parse_succeeded'] = False
+
+        return context
+
+    def parse_gsa_results(self, gsa_results):
+
+        results_meta = gsa_results['results_nav']
+
+        data = {}
+
+        # Parse data
+        if 'results' in gsa_results:
+            data['results'] = gsa_results['results']
+
+        if results_meta['total_results'].isdigit():
+            data['total'] = int(results_meta['total_results'])
+
+        if results_meta['results_start'].isdigit():
+            data['start'] = int(results_meta['results_start'])
+
+        if results_meta['results_end'].isdigit():
+            data['end'] = int(results_meta['results_end'])
+
+        data['have_next'] = bool(results_meta.get('have_next', '0'))
+
+        return data
+
+    def build_nav_items(self, data, url):
+        """
+        Create an array of navigational items
+        from results data
+        """
+
+        items = []
+
+        first_offset = 0
+        offset = data['start'] - 1
+        previous_offset = offset - data['limit']
+        next_offset = data['end']
+
+        remainder = data['total'] % data['limit']
+
+        if remainder == 0:
+            last_offset = data['total'] - data['limit']
+        else:
+            last_offset = data['total'] - remainder
+
+        base_item = {
+            "url": url + '&limit=' + str(data['limit'])
+        }
+
+        if first_offset < offset:
+            first = self.build_item(base_item, 'First', first_offset, 'back')
+            first['class'] = 'item-extreme'
+            items.append(first)
+
+        if previous_offset > first_offset and previous_offset < offset:
+            items.append(self.build_item(
+                base_item,
+                'Previous',
+                previous_offset,
+                'back'
+            ))
+
+        if data['have_next'] and next_offset < last_offset:
+            items.append(self.build_item(
+                base_item,
+                'Next',
+                next_offset,
+                'forward'
+            ))
+
+        if data['have_next'] and offset < last_offset:
+            last = self.build_item(base_item, 'Last', last_offset, 'forward')
+            last['class'] = 'item-extreme'
+            items.append(last)
+
+        return items
+
+    def build_item(self, base_item, name, offset, direction):
+        """
+        Build one navigational item
+        """
+
+        item = base_item.copy()
+        item['name'] = name
+        item['url'] = item['url'] + '&offset=' + str(offset)
+        item['direction'] = direction
+
+        return item


### PR DESCRIPTION
I've basically just copied exactly the search solution that's on www.ubuntu.com.

No access to search server
--

For the time being, there can be no access to the search server in local development or in demos.

The only way to properly test search would be to release this to staging. Even then, as things stand, it is searching the content of www.ubuntu.com.

So there are future tasks:

- Sort out local access to the search server (RT #98146)
- Ask IS to get (RT: #98154)
- Switch over to searching the developer.ubuntu.com index, instead of www.ubuntu.com

Example search results
--

So that search can work enough for it to be styled in local development, I've created `webapp/search.example` with the JSON output of searching for "ubuntu" on www.ubuntu.com.

In DEBUG mode, instead of attempting to contact the search server, we simply return this example search data.

QA
--

```
./run
```

Go to <http://127.0.0.1:8015/search?q=ubuntu>. See there are results, to be styled later.