### PR TITLE
Generate sidebar navigation from hardcoded dictionary

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,6 +15,6 @@ indent_style = space
 indent_size = 4
 
 # 2 space indentation
-[*.{css,js,scss}]
+[*.{css,js,scss,yaml}]
 indent_style = space
 indent_size = 2

--- a/templates/includes/base/sidebar.html
+++ b/templates/includes/base/sidebar.html
@@ -1,32 +1,6 @@
 <nav class="sidebar-nav__nav">
     <h2 class="sidebar-nav__title"><a class="sidebar-nav__title-link" href="/core">Core</a></h2>
-    <ul>
-        <li><a href="/core/get-started">Get started</a>
-            <ul>
-                <li><a href="/core/get-started">Link 1</a></li>
-                <li><a href="/core/get-started">Link 2</a></li>
-                <li><a href="/core/get-started">Link 3</a></li>
-                <li><a href="/core/get-started">Link 4</a></li>
-            </ul>
-        </li>
-        <li><a href="/core/tutorials">Tutorials</a></li>
-        <li><a href="/core/examples">Examples</a>
-            <ul>
-                <li><a href="/core/examples/gadget-snaps">Gadget snaps</a></li>
-                <li><a href="/core/examples/interfaces">Interfaces</a></li>
-                <li><a href="/core/examples/hooks">Hooks</a></li>
-                <li><a href="/core/examples/assertions">Assertions</a></li>
-            </ul>
-        </li>
-        <li><a href="/core/publish-and-distribute">Publish and distribute</a>
-            <ul>
-                <li><a href="/core/publish-and-distribute/publish">Publish</a></li>
-                <li><a href="/core/publish-and-distribute/distribute">Distribute</a></li>
-            </ul>
-        </li>
-        <li><a href="/core/documentation">Documentation</a></li>
-        <li><a href="/core/troubleshooting">Troubleshooting</a></li>
-    </ul>
+    {% sidebar_nav 'core' %}
 </nav>
 
 <script>

--- a/templates/includes/components/sidebar_nav.html
+++ b/templates/includes/components/sidebar_nav.html
@@ -1,0 +1,12 @@
+<ul>
+    {% for key, item in sitemap.children.items %}
+        <li><a href="{{ item.path }}">{{ item.title }}</a>
+        {% if item.children %}
+        <ul>
+            {% for key, item in item.children.items %}
+                <li><a href="{{ item.path }}">{{ item.title }}</a>
+            {% endfor %}
+        </ul>
+        {% endif %}
+    {% endfor %}
+</ul>

--- a/webapp/sitemap.py
+++ b/webapp/sitemap.py
@@ -1,0 +1,93 @@
+from collections import defaultdict, OrderedDict
+
+
+temporary_tree = OrderedDict([
+    ('core', {
+        'path': '/core',
+        'title': 'Core home',
+        'children': OrderedDict((
+            ('get-started', {
+                'path': '/core/get-started',
+                'title': 'Get started',
+            }),
+            ('tutorials', {
+                'path': '/core/tutorials',
+                'title': 'Tutorials',
+            }),
+            ('examples', {
+                'path': '/core/examples',
+                'title': 'Examples',
+                'children': {
+                    'gadget-snaps': {
+                        'path': '/core/examples/gadget-snaps',
+                        'title': 'Gadget snaps',
+                    },
+                    'interfaces': {
+                        'path': '/core/examples/interfaces',
+                        'title': 'Interfaces',
+                    },
+                    'hooks': {
+                        'path': '/core/examples/hooks',
+                        'title': 'Hooks',
+                    },
+                    'assertions': {
+                        'path': '/core/examples/assertions',
+                        'title': 'Assertions',
+                    },
+                },
+            }),
+            ('publish-and-distribute', {
+                'path': '/core/',
+                'title': 'Publish and distribute',
+                'children': {
+                    'publish': {
+                        'path': '/core/publish-and-distribute/publish',
+                        'title': 'Publish',
+                    },
+                    'distribute': {
+                        'path': '/core/publish-and-distribute/distribute',
+                        'title': 'Distribute',
+                    },
+                },
+            }),
+            ('documentation', {
+                'path': '/core/documentation',
+                'title': 'Documentation',
+            }),
+            ('troubleshooting', {
+                'path': '/core/troubleshooting',
+                'title': 'Troubleshooting',
+            }),
+        )),
+    }),
+])
+
+
+class SitemapTree(defaultdict):
+    def __init__(self):
+        pass
+
+
+class Sitemap:
+    def __init__(self):
+        self.sitemap = {}
+
+    def _generate_sitemap(self, root_path):
+        """
+        Generate a sitemap, starting from an optional given root_path.
+        This will return the whole sitemap upon completion.
+        """
+        tree = temporary_tree
+        if root_path:
+            self.sitemap[root_path] = tree['core']
+
+        return self.sitemap
+
+    def get(self, root_path=None):
+        if root_path:
+            full_map = self._generate_sitemap(root_path)
+            return full_map[root_path]
+        return self._generate_sitemap()
+
+
+sitemap = Sitemap()

--- a/webapp/templatetags.py
+++ b/webapp/templatetags.py
@@ -2,6 +2,7 @@ from django import template
 
 from webapp.lib.feeds import get_json_feed_content, get_rss_feed_content
 from webapp.lib.markdown import get_page_data
+from webapp.sitemap import sitemap
 
 register = template.Library()
 
@@ -33,4 +34,14 @@ def page_cards(context, pages):
     page_data = get_page_data(pages, request.path)
     return {
         'pages': page_data,
+    }
+
+
+@register.inclusion_tag(
+    'includes/components/sidebar_nav.html'
+)
+def sidebar_nav(root_path=None):
+    site_tree = sitemap.get(root_path)
+    return {
+        'sitemap': site_tree,
     }


### PR DESCRIPTION
Move sidebar creation to generation from a hardcoded dictionary.
This is the first step for generating from traversing the file tree, followed by a config file to specify ordering and other possible options.

This is using a template tag to load the navigation, to allow logic for loading the sitemap data.