### PR TITLE
Navigation generation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,6 +15,6 @@ indent_style = space
 indent_size = 4
 
 # 2 space indentation
-[*.{css,js,scss}]
+[*.{css,js,scss,yaml}]
 indent_style = space
 indent_size = 2

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,6 @@ mdx-anchors-away==1.0.1
 mdx-callouts==1.0.0
 mdx-foldouts==1.0.0
 python-frontmatter==0.2.1
+PyYAML==3.12
 requests==2.10.0
 requests-cache==0.4.12

--- a/templates/includes/base/sidebar.html
+++ b/templates/includes/base/sidebar.html
@@ -1,32 +1,6 @@
 <nav class="sidebar-nav__nav">
     <h2 class="sidebar-nav__title"><a class="sidebar-nav__title-link" href="/core">Core</a></h2>
-    <ul>
-        <li><a href="/core/get-started">Get started</a>
-            <ul>
-                <li><a href="/core/get-started">Link 1</a></li>
-                <li><a href="/core/get-started">Link 2</a></li>
-                <li><a href="/core/get-started">Link 3</a></li>
-                <li><a href="/core/get-started">Link 4</a></li>
-            </ul>
-        </li>
-        <li><a href="/core/tutorials">Tutorials</a></li>
-        <li><a href="/core/examples">Examples</a>
-            <ul>
-                <li><a href="/core/examples/gadget-snaps">Gadget snaps</a></li>
-                <li><a href="/core/examples/interfaces">Interfaces</a></li>
-                <li><a href="/core/examples/hooks">Hooks</a></li>
-                <li><a href="/core/examples/assertions">Assertions</a></li>
-            </ul>
-        </li>
-        <li><a href="/core/publish-and-distribute">Publish and distribute</a>
-            <ul>
-                <li><a href="/core/publish-and-distribute/publish">Publish</a></li>
-                <li><a href="/core/publish-and-distribute/distribute">Distribute</a></li>
-            </ul>
-        </li>
-        <li><a href="/core/documentation">Documentation</a></li>
-        <li><a href="/core/troubleshooting">Troubleshooting</a></li>
-    </ul>
+    {% sidebar_nav 'core' %}
 </nav>
 
 <script>

--- a/templates/includes/components/sidebar_nav.html
+++ b/templates/includes/components/sidebar_nav.html
@@ -8,5 +8,6 @@
             {% endfor %}
         </ul>
         {% endif %}
+        </li>
     {% endfor %}
 </ul>

--- a/templates/includes/components/sidebar_nav.html
+++ b/templates/includes/components/sidebar_nav.html
@@ -1,0 +1,12 @@
+<ul>
+    {% for key, item in sitemap.children.items %}
+        <li><a href="{{ item.path }}">{{ item.title }}</a>
+        {% if item.children %}
+        <ul>
+            {% for key, item in item.children.items %}
+                <li><a href="{{ item.path }}">{{ item.title }}</a>
+            {% endfor %}
+        </ul>
+        {% endif %}
+    {% endfor %}
+</ul>

--- a/templates/includes/navigation.yaml
+++ b/templates/includes/navigation.yaml
@@ -1,0 +1,27 @@
+root:
+  - Devices:
+    - Devices
+  - Topics:
+    - Development setup
+    - Ubuntu core
+    - Snapcraft
+    - Native apps
+    - Scops
+    - Web apps
+    - LXD containers
+    - MAAS
+  - Supporting content:
+    - Community resources
+    - Design
+
+core:
+  get-started:
+  tutorials:
+  examples:
+    gadget-snaps:
+    interfaces:
+    hooks:
+    assertions:
+  publish-and-distribute:
+  documentation:
+  troubleshooting:

--- a/templates/pages/core/reference/example-topic.md
+++ b/templates/pages/core/reference/example-topic.md
@@ -1,6 +1,0 @@
----
-title: Example topic
-description: A genuine honest-to-god topic
----
-
-This is some topic content.

--- a/webapp/lib/markdown/markdown.py
+++ b/webapp/lib/markdown/markdown.py
@@ -61,9 +61,12 @@ def get_page_data(pages, root_path=None):
     for path in pages:
         # If trying to lookup relative path
         if root_path and not path.startswith('/'):
+            root_path = root_path.strip('/')
             path = '/'.join([root_path, path])
         # We don't need any slashes at the ends
-        path.strip('/')
+        path = path.strip('/')
+        if path.endswith('/index'):
+            path = path[:-6]
 
         template_paths = [
             ''.join([template_root, path, '.md']),
@@ -72,7 +75,7 @@ def get_page_data(pages, root_path=None):
 
         with open(template.origin.name, 'r') as f:
             markdown_content, metadata = parse_frontmatter(f.read())
-            metadata['path'] = path
+            metadata['path'] = '/' + path
             page_data.append(metadata)
 
     return page_data

--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -37,6 +37,7 @@ APPEND_SLASH = False
 REMOVE_SLASH = True
 STATIC_ROOT = "static"
 STATIC_URL = '/static/'
+TEMPLATE_PATH = os.path.join(BASE_DIR, 'templates')
 TEMPLATE_FINDER_PATH = 'pages'
 
 WHITENOISE_ALLOW_ALL_ORIGINS = False
@@ -61,7 +62,7 @@ STATICFILES_FINDERS = [
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [os.path.join(BASE_DIR, 'templates')],
+        'DIRS': [TEMPLATE_PATH],
         'OPTIONS': {
             'builtins': [
                 'webapp.templatetags',

--- a/webapp/sitemap.py
+++ b/webapp/sitemap.py
@@ -1,83 +1,99 @@
-from collections import defaultdict, OrderedDict
+# Core modules
+import fnmatch
+import os
+from copy import deepcopy
 
+# Third party modules
+from django.conf import settings
 
-temporary_tree = OrderedDict([
-    ('core', {
-        'path': '/core',
-        'title': 'Core home',
-        'children': OrderedDict((
-            ('get-started', {
-                'path': '/core/get-started',
-                'title': 'Get started',
-            }),
-            ('tutorials', {
-                'path': '/core/tutorials',
-                'title': 'Tutorials',
-            }),
-            ('examples', {
-                'path': '/core/examples',
-                'title': 'Examples',
-                'children': {
-                    'gadget-snaps': {
-                        'path': '/core/examples/gadget-snaps',
-                        'title': 'Gadget snaps',
-                    },
-                    'interfaces': {
-                        'path': '/core/examples/interfaces',
-                        'title': 'Interfaces',
-                    },
-                    'hooks': {
-                        'path': '/core/examples/hooks',
-                        'title': 'Hooks',
-                    },
-                    'assertions': {
-                        'path': '/core/examples/assertions',
-                        'title': 'Assertions',
-                    },
-                },
-            }),
-            ('publish-and-distribute', {
-                'path': '/core/',
-                'title': 'Publish and distribute',
-                'children': {
-                    'publish': {
-                        'path': '/core/publish-and-distribute/publish',
-                        'title': 'Publish',
-                    },
-                    'distribute': {
-                        'path': '/core/publish-and-distribute/distribute',
-                        'title': 'Distribute',
-                    },
-                },
-            }),
-            ('documentation', {
-                'path': '/core/documentation',
-                'title': 'Documentation',
-            }),
-            ('troubleshooting', {
-                'path': '/core/troubleshooting',
-                'title': 'Troubleshooting',
-            }),
-        )),
-    }),
-])
-
-
-class SitemapTree(defaultdict):
-    def __init__(self):
-        pass
+# Local modules
+from webapp.lib.markdown import get_page_data
 
 
 class Sitemap:
     def __init__(self):
         self.sitemap = {}
 
+    def _get_template_path(self):
+        template_path = getattr(settings, 'TEMPLATE_PATH')
+        pages_path = getattr(settings, 'TEMPLATE_FINDER_PATH')
+        if pages_path and not pages_path.startswith('/'):
+            template_path = os.path.join(template_path, pages_path)
+        return template_path
+
+    def _build_metadata(self, path):
+        if path.endswith('/'):
+            path = path[:-1]
+        metadata = get_page_data([path])[0]
+        return {
+            'title': metadata.get('title'),
+            'description': metadata.get('description'),
+            'path': metadata.get('path'),
+        }
+
+    def _parse_markdown_files(self, root_path=None):
+        default_node = {'children': {}}
+        nodes = {}
+
+        path = self._get_template_path()
+        walk_path = path
+        if root_path:
+            walk_path = os.path.join(path, root_path)
+
+        for root, dirnames, filenames in os.walk(walk_path):
+            relative_path = os.path.relpath(root, path)
+            if relative_path == '.':
+                relative_path = ''
+
+            for filename in fnmatch.filter(filenames, '*.md'):
+                if not filename:
+                    continue
+
+                is_index = False
+                if filename == 'index.md':
+                    is_index = True
+
+                file_path = os.path.join(relative_path, filename)
+                if file_path.endswith('.md'):
+                    file_path = file_path[:-3]
+
+                metadata = self._build_metadata(file_path)
+
+                # Nest path parts as a dictionary.
+                # As it loops, we update the current_node reference to the
+                # next level of dictionary.
+                path_parts = file_path.split('/')
+                current_node = nodes
+                for part in path_parts[:-1]:
+                    # Split up levels by using a 'children' key.
+                    if current_node is not nodes:
+                        current_node = current_node['children']
+                    # Creates a node if it does not exist
+                    current_node = current_node.setdefault(
+                        part, deepcopy(default_node)
+                    )
+
+                if is_index:
+                    current_node.update(metadata)
+                    continue
+
+                current_node = current_node['children']
+                if current_node.get(path_parts[-1]):
+                    current_node[path_parts[-1]].update(metadata)
+                else:
+                    current_node[path_parts[-1]] = metadata
+
+        return nodes
+
     def _generate_sitemap(self, root_path):
         """
         Generate a sitemap, starting from an optional given root_path.
         This will return the whole sitemap upon completion.
         """
-        tree = temporary_tree
+        markdown_files = self._parse_markdown_files(root_path)
+
+        tree = markdown_files
+        print tree
         if root_path:
             self.sitemap[root_path] = tree['core']
 

--- a/webapp/sitemap.py
+++ b/webapp/sitemap.py
@@ -1,0 +1,93 @@
+from collections import defaultdict, OrderedDict
+
+
+temporary_tree = OrderedDict([
+    ('core', {
+        'path': '/core',
+        'title': 'Core home',
+        'children': OrderedDict((
+            ('get-started', {
+                'path': '/core/get-started',
+                'title': 'Get started',
+            }),
+            ('tutorials', {
+                'path': '/core/tutorials',
+                'title': 'Tutorials',
+            }),
+            ('examples', {
+                'path': '/core/examples',
+                'title': 'Examples',
+                'children': {
+                    'gadget-snaps': {
+                        'path': '/core/examples/gadget-snaps',
+                        'title': 'Gadget snaps',
+                    },
+                    'interfaces': {
+                        'path': '/core/examples/interfaces',
+                        'title': 'Interfaces',
+                    },
+                    'hooks': {
+                        'path': '/core/examples/hooks',
+                        'title': 'Hooks',
+                    },
+                    'assertions': {
+                        'path': '/core/examples/assertions',
+                        'title': 'Assertions',
+                    },
+                },
+            }),
+            ('publish-and-distribute', {
+                'path': '/core/',
+                'title': 'Publish and distribute',
+                'children': {
+                    'publish': {
+                        'path': '/core/publish-and-distribute/publish',
+                        'title': 'Publish',
+                    },
+                    'distribute': {
+                        'path': '/core/publish-and-distribute/distribute',
+                        'title': 'Distribute',
+                    },
+                },
+            }),
+            ('documentation', {
+                'path': '/core/documentation',
+                'title': 'Documentation',
+            }),
+            ('troubleshooting', {
+                'path': '/core/troubleshooting',
+                'title': 'Troubleshooting',
+            }),
+        )),
+    }),
+])
+
+
+class SitemapTree(defaultdict):
+    def __init__(self):
+        pass
+
+
+class Sitemap:
+    def __init__(self):
+        self.sitemap = {}
+
+    def _generate_sitemap(self, root_path):
+        """
+        Generate a sitemap, starting from an optional given root_path.
+        This will return the whole sitemap upon completion.
+        """
+        tree = temporary_tree
+        if root_path:
+            self.sitemap[root_path] = tree['core']
+
+        return self.sitemap
+
+    def get(self, root_path=None):
+        if root_path:
+            full_map = self._generate_sitemap(root_path)
+            return full_map[root_path]
+        return self._generate_sitemap()
+
+
+sitemap = Sitemap()

--- a/webapp/sitemap.py
+++ b/webapp/sitemap.py
@@ -124,7 +124,8 @@ class Sitemap:
 
     def build_navigation(self, root_path=None):
         """
-
+        Order the sitemap using a yaml config.
+        Return a sitemap built with OrderedDict
         """
         template_path = getattr(settings, 'TEMPLATE_PATH')
         config_path = os.path.join(

--- a/webapp/templatetags.py
+++ b/webapp/templatetags.py
@@ -41,7 +41,7 @@ def page_cards(context, pages):
     'includes/components/sidebar_nav.html'
 )
 def sidebar_nav(root_path=None):
-    site_tree = sitemap.get(root_path)
+    site_tree = sitemap.build_navigation(root_path)
     return {
         'sitemap': site_tree,
     }

--- a/webapp/templatetags.py
+++ b/webapp/templatetags.py
@@ -2,6 +2,7 @@ from django import template
 
 from webapp.lib.feeds import get_json_feed_content, get_rss_feed_content
 from webapp.lib.markdown import get_page_data
+from webapp.sitemap import sitemap
 
 register = template.Library()
 
@@ -33,4 +34,14 @@ def page_cards(context, pages):
     page_data = get_page_data(pages, request.path)
     return {
         'pages': page_data,
+    }
+
+
+@register.inclusion_tag(
+    'includes/components/sidebar_nav.html'
+)
+def sidebar_nav(root_path=None):
+    site_tree = sitemap.get(root_path)
+    return {
+        'sitemap': site_tree,
     }


### PR DESCRIPTION
Load navigation through the sitemap module. This navigation is generated from the defined order inside a yaml file.

It loops through the yaml file and looks up the item from the sitemap. Currently it loads items directly in the yaml file but there is space for allowing more control from the yaml file with extra config options.

# QA
`./run` the site
Check that navigation matches yaml ordering, and correctly loads the title and correct path from page metadata.