### PR TITLE
Lowercase metadata keys in pages

### DIFF
--- a/templates/pages/core/get-started/artik-5-10.md
+++ b/templates/pages/core/get-started/artik-5-10.md
@@ -1,6 +1,6 @@
 ---
-Title: Samsung Artik 5 or 10
-Description: These steps will walk you through flashing Ubuntu Core on a Samsung Artik 5 or 10.
+title: Samsung Artik 5 or 10
+description: These steps will walk you through flashing Ubuntu Core on a Samsung Artik 5 or 10.
 ---
 
 # Samsung Artik 5 or 10

--- a/templates/pages/core/get-started/developer-setup.md
+++ b/templates/pages/core/get-started/developer-setup.md
@@ -1,6 +1,6 @@
 ---
-Title: Developer setup
-Description: These steps will walk you through installing a developer environment on an Ubuntu Core device.
+title: Developer setup
+description: These steps will walk you through installing a developer environment on an Ubuntu Core device.
 ---
 
 # Developer setup

--- a/templates/pages/core/get-started/dragonboard-410c.md
+++ b/templates/pages/core/get-started/dragonboard-410c.md
@@ -1,6 +1,6 @@
 ---
-Title: DragonBoard 410c
-Description: These steps will walk you through flashing Ubuntu Core on a DragonBoard 410c.
+title: DragonBoard 410c
+description: These steps will walk you through flashing Ubuntu Core on a DragonBoard 410c.
 ---
 
 # DragonBoard 410c

--- a/templates/pages/core/get-started/intel-joule.md
+++ b/templates/pages/core/get-started/intel-joule.md
@@ -1,6 +1,6 @@
 ---
-Title: Intel Joule
-Description: These steps will walk you through flashing Ubuntu Core on an Intel Joule.
+title: Intel Joule
+description: These steps will walk you through flashing Ubuntu Core on an Intel Joule.
 ---
 # Intel Joule
 

--- a/templates/pages/core/get-started/intel-nuc.md
+++ b/templates/pages/core/get-started/intel-nuc.md
@@ -1,6 +1,6 @@
 ---
-Title: Intel Nuc
-Description: These steps will walk you through flashing Ubuntu Core on an Intel NUC.
+title: Intel Nuc
+description: These steps will walk you through flashing Ubuntu Core on an Intel NUC.
 ---
 # Intel Nuc
 

--- a/templates/pages/core/get-started/kvm.md
+++ b/templates/pages/core/get-started/kvm.md
@@ -1,6 +1,6 @@
 ---
-Title: KVM
-Description: These steps will walk you through installing Ubuntu Core on your Linux desktop in a virtual machine.
+title: KVM
+description: These steps will walk you through installing Ubuntu Core on your Linux desktop in a virtual machine.
 ---
 # KVM
 

--- a/templates/pages/core/get-started/raspberry-pi-2-3.md
+++ b/templates/pages/core/get-started/raspberry-pi-2-3.md
@@ -1,6 +1,6 @@
 ---
-Title: Raspberry Pi 2 or 3
-Description: These steps will walk you through flashing Ubuntu Core on a Raspberry Pi 2 or 3.
+title: Raspberry Pi 2 or 3
+description: These steps will walk you through flashing Ubuntu Core on a Raspberry Pi 2 or 3.
 ---
 # Raspberry Pi 2 or 3
 


### PR DESCRIPTION
This is an immediate fix to correct the issue with not displaying page titles.