### PR TITLE
Add template tag to truncate text

### DIFF
--- a/webapp/templatetags.py
+++ b/webapp/templatetags.py
@@ -45,3 +45,14 @@ def sidebar_nav(root_path=None):
     return {
         'sitemap': site_tree,
     }
+
+
+@register.filter
+def truncate_chars(value, max_length):
+    length = len(value)
+    if length > max_length:
+        truncated = value[:max_length]
+        if not length == (max_length + 1) and value[max_length + 1] != " ":
+            truncated = truncated[:truncated.rfind(" ")]
+        return truncated + "&hellip;"
+    return value


### PR DESCRIPTION
Adding truncate template filter for Graham to use in his current work.

Usage: `{{ item.description|truncate_chars:100 }}`
which echos the variable limit to 100 characters, at the closest word.