### PR TITLE
Remove IoT link from header

### DIFF
--- a/templates/includes/base/header.html
+++ b/templates/includes/base/header.html
@@ -16,17 +16,16 @@
               <a class="p-navigation__link" href="https://developer.ubuntu.com/en/desktop/">Desktop</a>
               <a class="p-navigation__link" href="https://developer.ubuntu.com/en/phone/">Phone</a>
               <a class="p-navigation__link" href="/core">Core</a>
-              <a class="p-navigation__link" href="https://developer.ubuntu.com/en/snappy/">IoT</a>
               <a class="p-navigation__link" href="https://developer.ubuntu.com/en/community/">Community</a>
               <a class="p-navigation__link" href="https://developer.ubuntu.com/en/publish/">Publish</a>
               <a class="p-navigation__link" href="https://myapps.developer.ubuntu.com/">My Apps</a>
             </div>
-            
+
             <!-- <form id="form-search" action="/en/search/" class="header-search">
                 <label for="edit-keys" class="accessibility-aid">Search</label>
                 <input type="search" maxlength="255" name="q" id="search" class="form-text" placeholder="Search" value="" />
                 <button type="submit"><img src="{{ ASSET_SERVER_URL }}2196e362-search-white.svg" alt="Search" height="28" /></button>
-            </form> -->          
+            </form> -->
         </nav>
     </div>
 </header>


### PR DESCRIPTION
Does what it says on the tin.


On the live site, IoT section will be renamed to core and pointed at this site. This matches that outcome.