### PR TITLE
Set active navigation items

### DIFF
--- a/templates/includes/base/sidebar.html
+++ b/templates/includes/base/sidebar.html
@@ -1,5 +1,5 @@
 <nav class="sidebar-nav__nav">
-    <h2 class="sidebar-nav__title"><a class="sidebar-nav__title-link" href="/core">Core</a></h2>
+    <h2 class="sidebar-nav__title"><a class="sidebar-nav__title-link{% if request.path == '/core' %} active{% endif %}" href="/core">Core</a></h2>
     {% sidebar_nav 'core' %}
 </nav>
 

--- a/templates/includes/components/sidebar_nav.html
+++ b/templates/includes/components/sidebar_nav.html
@@ -1,10 +1,10 @@
 <ul>
     {% for key, item in sitemap.children.items %}
-        <li><a href="{{ item.path }}">{{ item.title }}</a>
+        <li><a href="{{ item.path }}" class="{{ item.class|default:"" }}">{{ item.title }}</a>
         {% if item.children %}
         <ul>
             {% for key, item in item.children.items %}
-                <li><a href="{{ item.path }}">{{ item.title }}</a>
+                <li><a href="{{ item.path }}" class="{{ item.class|default:"" }}">{{ item.title }}</a>
             {% endfor %}
         </ul>
         {% endif %}

--- a/webapp/templatetags.py
+++ b/webapp/templatetags.py
@@ -38,10 +38,14 @@ def page_cards(context, pages):
 
 
 @register.inclusion_tag(
-    'includes/components/sidebar_nav.html'
+    'includes/components/sidebar_nav.html', takes_context=True
 )
-def sidebar_nav(root_path=None):
-    site_tree = sitemap.build_navigation(root_path)
+def sidebar_nav(context, root_path=None):
+    request = context['request']
+    site_tree = sitemap.build_navigation(
+        root_path=root_path,
+        current_path=request.path,
+    )
     return {
         'sitemap': site_tree,
     }


### PR DESCRIPTION
Set active items in the navigation bar, based on the current path.

It sets while while building the navigation. It splits the current path, and loops through the nested items to mark as relevant.

# QA
`./run`
Make sure `active` class shows on current page entry, and `active-parent` shows on the parent items.