### PR TITLE
Content review changes

### DIFF
--- a/templates/includes/navigation.yaml
+++ b/templates/includes/navigation.yaml
@@ -16,6 +16,12 @@ root:
 
 core:
   get-started:
+    raspberry-pi-2-3:
+    intel-joule:
+    dragonboard-410c:
+    intel-nuc:
+    artik-5-10:
+    kvm:
   tutorials:
   examples:
     hooks:

--- a/templates/includes/navigation.yaml
+++ b/templates/includes/navigation.yaml
@@ -16,12 +16,6 @@ root:
 
 core:
   get-started:
-    raspberry-pi-2-3:
-    intel-joule:
-    dragonboard-410c:
-    intel-nuc:
-    artik-5-10:
-    kvm:
   tutorials:
   examples:
     hooks:

--- a/templates/pages/core/tutorials.md
+++ b/templates/pages/core/tutorials.md
@@ -19,7 +19,7 @@ To get started, install the snap:
 $ sudo snap install snap-codelabs
 ```
 
-You can then access the snap at `http://localhost:8123/` (port 8123 on your local machine).
+You can then access the snap by visiting `http://localhost:8123/` in your browser.
 
 ## Available tutorials
 

--- a/templates/pages/core/tutorials.md
+++ b/templates/pages/core/tutorials.md
@@ -1,13 +1,13 @@
-----
+---
 title: Tutorials
 description: A series of tutorials, step by step practical guides to help you achieve a variety of tasks from writing your first snap to building a node.js service.
-----
+---
 
 # Tutorials
 
-Tutorials are practical guides, with step-by-step instructions to achieve the most common development tasks. They cover a variety of areas from getting started tasks to more advanced topics. Easy to follow, practical, and instructive, they should give you an understanding of key Ubuntu Core concepts and, more importantly, help you build components of your solution.
-
 Tutorials are still in beta, but to get an early preview, you can access the offline snap version of the tutorials. To give us feedback or to ask for new tutorials to be created, please [file an issue](https://github.com/ubuntu/codelabs/issues) on the GitHub project.
+
+Tutorials are practical guides, with step-by-step instructions to achieve the most common development tasks. They cover a variety of areas from getting started tasks to more advanced topics. Easy to follow, practical, and instructive, they should give you an understanding of key Ubuntu Core concepts and, more importantly, help you build components of your solution.
 
 ## Tutorials in a snap
 
@@ -19,7 +19,7 @@ To get started, install the snap:
 $ sudo snap install snap-codelabs
 ```
 
-You can then access the snap on your [local machine](http://localhost:8123/) at port 8123.
+You can then access the snap at `http://localhost:8123/` (port 8123 on your local machine).
 
 ## Available tutorials
 

--- a/templates/pages/core/tutorials.md
+++ b/templates/pages/core/tutorials.md
@@ -7,7 +7,7 @@ description: A series of tutorials, step by step practical guides to help you ac
 
 Tutorials are practical guides, with step-by-step instructions to achieve the most common development tasks. They cover a variety of areas from getting started tasks to more advanced topics. Easy to follow, practical, and instructive, they should give you an understanding of key Ubuntu Core concepts and, more importantly, help you build components of your solution.
 
-Tutorials are still in beta, but to get an early preview, you can access the offline snap version of the tutorials. To give us feedback or to ask for new tutorials to be created, please [file an issue](https://github.com/ubuntu/codelabs/issues) on the GitHub project.`
+Tutorials are still in beta, but to get an early preview, you can access the offline snap version of the tutorials. To give us feedback or to ask for new tutorials to be created, please [file an issue](https://github.com/ubuntu/codelabs/issues) on the GitHub project.
 
 ## Tutorials in a snap
 

--- a/templates/pages/core/tutorials.md
+++ b/templates/pages/core/tutorials.md
@@ -5,9 +5,9 @@ description: A series of tutorials, step by step practical guides to help you ac
 
 # Tutorials
 
-Tutorials are still in beta, but to get an early preview, you can access the offline snap version of the tutorials. To give us feedback or to ask for new tutorials to be created, please [file an issue](https://github.com/ubuntu/codelabs/issues) on the GitHub project.
-
 Tutorials are practical guides, with step-by-step instructions to achieve the most common development tasks. They cover a variety of areas from getting started tasks to more advanced topics. Easy to follow, practical, and instructive, they should give you an understanding of key Ubuntu Core concepts and, more importantly, help you build components of your solution.
+
+Tutorials are still in beta, but to get an early preview, you can access the offline snap version of the tutorials. To give us feedback or to ask for new tutorials to be created, please [file an issue](https://github.com/ubuntu/codelabs/issues) on the GitHub project.`
 
 ## Tutorials in a snap
 


### PR DESCRIPTION
Changes from our content review meeting. See commits for description:

- Replace confusing link to `localhost` on the tutorial page with instructions to go to localhost
- Swap second paragraph with first in tutorials page to make it clearer that this is beta
- Fix the sub-navigation under get-started