### PR TITLE
Fix get started links

### DIFF
--- a/templates/includes/components/grid_cards.html
+++ b/templates/includes/components/grid_cards.html
@@ -3,7 +3,7 @@
         <li class="col-6 grid-list__item{% if forloop.last %} last-item{% endif %}{% cycle ' odd' ' even' %}">
             {% if page.image %}<div class="grid-list__image-container"><img class="grid-list__image" alt="{{ page.title }} logo" src="{{ page.image }}"></div>{% endif %}
             <div class="grid-list__description"><p>{{ page.description }}</p></div>
-            <p class=""><a href="{{ page.path }}">Get started<span class="u-off-screen"> with {{ page.title }}</span> &rsaquo;</a></p>
+            <p class=""><a href="{{ page.path }}">Get started on {{ page.title }} &rsaquo;</a></p>
         </li>
     {% endfor %}
 </ul>


### PR DESCRIPTION
## Done

Change get started links so they display the name of the board 


## QA

Should be a visual to make sure the name of the board is displayed