### PR TITLE
Fix external link icons in all browsers

### DIFF
--- a/templates/includes/base.html
+++ b/templates/includes/base.html
@@ -36,6 +36,47 @@
     }</script>
 <!-- End Google Tag Manager -->    
     
+<!-- Polyfills -->
+<script>
+  /* Polyfill functions
+   * =================== */
+
+  /**
+   * Array.prototype.forEach polyfill
+   * from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach
+   */
+  if (!Array.prototype.forEach) {
+	  Array.prototype.forEach = function(fun) {
+		  if (
+			  this === void 0
+			  || this === null
+			  || typeof fun !== "function"
+		  ) { throw new TypeError(); }
+
+		  var t = Object(this);
+		  var len = t.length >>> 0;
+
+		  var thisArg = arguments.length >= 2 ? arguments[1] : void 0;
+		  for (var i = 0; i < len; i++) {
+			  if (i in t) {
+				  fun.call(thisArg, t[i], i, t);
+			  }
+		  }
+	  };
+  }
+
+  /**
+   * Add Array methods to NodeList
+   */
+  Object.getOwnPropertyNames(Array.prototype).forEach(
+	function (methodName) {
+	  if(!(methodName in NodeList.prototype)) {
+		NodeList.prototype[methodName] = Array.prototype[methodName];
+	  }
+	}
+  );
+</script>
+
 </head>
 
 <body class="theme">


### PR DESCRIPTION
For poor browsers that don't support NodeList.forEach.

Fixed #203

QA
--

If you really want to QA it, try in browserstack (with [local plugin](https://chrome.google.com/webstore/detail/browserstack-local/mfiddfehmfdojjfdpfngagldgaaafcfo?hl=en)) on one of:

- Edge browser
- IE 11
- Firefox <= 49

Then compare <https://developer.ubuntu.com/core/documentation> to <http://127.0.0.1:8015/core/documentation>.