### PR TITLE
Filter search results to exclude zh-CN

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,5 +16,5 @@ python-frontmatter==0.2.1
 PyYAML==3.12
 requests==2.10.0
 requests-cache==0.4.12
-ubuntudesign.gsa==0.1.1
+ubuntudesign.gsa==1.0.0
 

--- a/templates/pages/search.html
+++ b/templates/pages/search.html
@@ -37,6 +37,36 @@
 
             <p class="bottom-results-total result-line">Results {{ results.start }} to {{ results.end }} of {{ results.total }}</p>
         </section>
+
+            {% if results.last_page > 1 %}
+            <nav class="pagination" id="page-nav">
+                {% if results.current_page > 1 %}
+                <ul class="pagination__back">
+                    <li class="pagination__item">
+                        <a href="/search?q={{ query }}&limit={{ limit }}&offset=0">&#8249;&#8249; First</a>
+                    </li>
+                    {% if results.current_page > 2 %}
+                    <li class="pagination__item">
+                        <a href="/search?q={{ query }}&limit={{ limit }}&offset={{ results.previous_offset }}">&#8249; Previous</a>
+                    </li>
+                    {% endif %}
+                </ul>
+                {% endif %}
+
+                {% if results.current_page != results.last_page %}
+                <ul class="pagination__forward">
+                    {% if results.current_page < results.penultimate_page %}
+                    <li class="pagination__item">
+                        <a href="/search?q={{ query }}&limit={{ limit }}&offset={{ results.next_offset }}">Next &#8250;</a>
+                    </li>
+                    {% endif %}
+                    <li class="pagination__item">
+                        <a href="/search?q={{ query }}&limit={{ limit }}&offset={{ results.last_page_offset }}">Last &#8250;&#8250;</a>
+                    </li>
+                </ul>
+                {% endif %}
+            </nav>
+            {% endif %}
         {% else %}
         <h2>Sorry we couldn't find "{{ query }}"</h2>
 
@@ -54,36 +84,6 @@
             <li><a href="https://bugs.launchpad.net/developer-ubuntu-com/">Report an issue with the site</a></li>
         </ul>
         {% endif %} {# results #}
-
-        {% if results.total > 0 %}
-        <nav class="pagination" id="page-nav">
-            {% if not results.first_page %}
-            <ul class="pagination__back">
-                <li class="pagination__item">
-                    <a href="/search?q={{ query }}&limit={{ limit }}&offset=0">&#8249;&#8249; First</a>
-                </li>
-                {% if not results.second_page %}
-                <li class="pagination__item">
-                    <a href="/search?q={{ query }}&limit={{ limit }}&offset={{ results.previous_offset }}">&#8249; Previous</a>
-                </li>
-                {% endif %}
-            </ul>
-            {% endif %}
-
-            {% if not results.last_page %}
-            <ul class="pagination__forward">
-                {% if not results.penultimate_page %}
-                <li class="pagination__item">
-                    <a href="/search?q={{ query }}&limit={{ limit }}&offset={{ results.next_offset }}">Next &#8250;</a>
-                </li>
-                {% endif %}
-                <li class="pagination__item">
-                    <a href="/search?q={{ query }}&limit={{ limit }}&offset={{ results.last_page_offset }}">Last &#8250;&#8250;</a>
-                </li>
-            </ul>
-            {% endif %}
-        </nav>
-        {% endif %}
     {% endif %}
 {% endif %} {# query #}
     </div>

--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -39,6 +39,7 @@ USE_TZ = False
 # SEARCH_SERVER_URL = 'http://butlerov.internal/search'
 SEARCH_SERVER_URL = 'http://10.22.112.8/search'
 SEARCH_DOMAINS = ['developer.ubuntu.com']
+SEARCH_LANGUAGE = '-lang_zh-CN'
 
 WSGI_APPLICATION = 'webapp.wsgi.application'
 ROOT_URLCONF = 'webapp.urls'


### PR DESCRIPTION
Because the Chinese pages on developer.ubuntu.com/zh-CN are largely very out-of-date, we're excluding them from the search results.

This also enables the `domain=` and `language=` parameters on the `/search` view.

Version 1.0.0 provides a slightly different template context object to the template, so I am updating the template slightly.

Resolves #215.

QA
---

While *connected to the VPN*, run the site natively:

``` bash
virtualenv env
env/bin/pip install -r requirements.txt
env/bin/python manage.py runserver 0.0.0.0:8015
```

Visit search, check it all works as expected: <http://127.0.0.1:8015/search>.