### PR TITLE
Search across multiple domains

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,5 +16,5 @@ python-frontmatter==0.2.1
 PyYAML==3.12
 requests==2.10.0
 requests-cache==0.4.12
-ubuntudesign.gsa==1.0.0
+ubuntudesign.gsa==1.0.1
 

--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -38,7 +38,11 @@ USE_TZ = False
 
 # SEARCH_SERVER_URL = 'http://butlerov.internal/search'
 SEARCH_SERVER_URL = 'http://10.22.112.8/search'
-SEARCH_DOMAINS = ['developer.ubuntu.com']
+SEARCH_DOMAINS = [
+    'developer.ubuntu.com',
+    'docs.ubuntu.com',
+    'tutorials.ubuntu.com',
+]
 SEARCH_LANGUAGE = '-lang_zh-CN'
 
 WSGI_APPLICATION = 'webapp.wsgi.application'


### PR DESCRIPTION
- Use v1.0.1 of ubuntudesign.gsa which fixed domain searching
- Search across developer, docs and tutorials

QA
---

Connect to VPN and Run search, natively:

``` bash
./run npm run-script watch  # Run the cancel out, to rebuild sass
virtualenv env
env/bin/pip install -r requirements.txt
env/bin/python manage.py runserver 0.0.0.0:8015
```

Go to <http://127.0.0.1:8015/search>. Search for "tutorials", check you see tutorials.ubuntu.com. Check other searches return results from developer.ubuntu.com and docs.ubuntu.com, but no other domains.