### PR TITLE
Remove styles that made docs theme look like developer

### DIFF
--- a/static/sass/_global-settings.scss
+++ b/static/sass/_global-settings.scss
@@ -13,5 +13,5 @@ $color-search-result-border: #cdcdcd;
 $color-search-result-url: #888;
 $color-tutorial-card-header-font: #fff;
 $color-tutorial-card-meta-font: #666;
-$color-tutorial-card-separator: e8e8e8;
+$color-tutorial-card-separator: #e8e8e8;
 $asset-server-url: 'https://assets.ubuntu.com/v1/';

--- a/static/sass/_header.scss
+++ b/static/sass/_header.scss
@@ -1,5 +1,4 @@
 .banner {
-  max-width: $site-max-width;
 
   .p-navigation__toggle--open {
     background-image: url('#{$asset-server-url}4447809f-navigation-menu-plain.svg');

--- a/static/sass/_sidebar-nav.scss
+++ b/static/sass/_sidebar-nav.scss
@@ -1,9 +1,7 @@
 @import 'helpers';
 
 .theme__sidebar {
-  @include rounded-corners(4px 4px 0);
   background: $color-x-light;
-  border-left: 1px solid $color-mid-light;
   display: flex;
   padding: 10px 0 0;
 }

--- a/static/sass/global.scss
+++ b/static/sass/global.scss
@@ -12,33 +12,8 @@
 'helpers',
 'search';
 
-
 .nav-global-main {
   margin-top: 0;
-}
-
-body {
-  background: $color-light; // temporary style
-}
-
-.theme__wrap,
-.p-footer__inner {
-  margin: 0 auto;
-
-  @media only screen and (min-width: $breakpoint-large) {
-    width: $breakpoint-large;
-  }
-}
-
-.theme__wrap {
-  background: $color-x-light;
-  clear: both;
-
-  @media only screen and (min-width: $breakpoint-large) {
-    @include rounded-corners(4px);
-    box-shadow: 0 0 3px $color-mid-light;
-    margin-bottom: 30px !important;
-  }
 }
 
 a,
@@ -74,10 +49,6 @@ a:link:hover {
   padding-top: 0;
 }
 
-.theme__inner {
-  margin: 0 auto;
-}
-
 .theme {
   .p-navigation {
     background: $color-brand;
@@ -88,7 +59,6 @@ a:link:hover {
 
     @media only screen and (min-width: $breakpoint-large) {
       border-bottom: 0;
-      margin-bottom: 30px; // temporary style
     }
 
     .p-navigation__toggle {

--- a/static/sass/global.scss
+++ b/static/sass/global.scss
@@ -87,16 +87,6 @@ a:link:hover {
       width: 25px;
     }
 
-    .p-navigation__inner {
-      border-color: $color-mid-light;
-      width: auto;
-
-      @media only screen and (min-width: $breakpoint-medium) {
-        margin: 0 auto;
-        width: $breakpoint-large;
-      }
-    }
-
     &__links {
       background: darken($color-light, 3%);
       float: left;

--- a/templates/includes/base/header.html
+++ b/templates/includes/base/header.html
@@ -20,14 +20,6 @@
             <span class="u-off-screen">
                 <a href="#main-content">Jump to main content</a>
             </span>
-            <div class="p-navigation__links u-clearfix col-12">
-              <a class="p-navigation__link" href="https://developer.ubuntu.com/en/desktop/">Desktop</a>
-              <a class="p-navigation__link" href="https://developer.ubuntu.com/en/phone/">Phone</a>
-              <a class="p-navigation__link" href="/core">Core</a>
-              <a class="p-navigation__link" href="https://developer.ubuntu.com/en/community/">Community</a>
-              <a class="p-navigation__link" href="https://developer.ubuntu.com/en/publish/">Publish</a>
-              <a class="p-navigation__link p-navigation__link--last-item" href="https://myapps.developer.ubuntu.com/">My Apps</a>
-            </div>
         </nav>
 
         <form id="search" action="/search" class="header-search">


### PR DESCRIPTION
## Done

Remove temporary styles that were added to make the docs theme look like the old developer theme.
Remove main nav as this is moving to left had sidebar

## QA

- Follow the instructions in README.md to get started
- Go to http://localhost:8015/core and it should look more like the docs theme compared to https://developer.ubuntu.com/core

This still needs work but there's a bug in the run script that’s stopping the docs them from overriding vanilla on sass compile, Will’s looking at this atm

