### PR TITLE
Add links to Raspi target-platforms include

### DIFF
--- a/templates/includes/components/target-platforms.html
+++ b/templates/includes/components/target-platforms.html
@@ -4,12 +4,12 @@
         <p class="p-card__content">Ubuntu supports the Raspberry Pi 2 and 3.</p>
         
         <p>Get started with an Ubuntu Server image for a familiar development environment.</p>
-        <p><a href="">How to flash Ubuntu on Raspberry Pi [link needed]</a></p>
+        <p><a href="https://wiki.ubuntu.com/ARM/RaspberryPi">How to flash Ubuntu on Raspberry Pi</a></p>
         
         <p>Use Ubuntu Core when you are ready to move to a production environment.</p>
-        <p><a href="">Flash Ubuntu Core [link needed]</a></p>
+        <p><a href="/core/get-started/raspberry-pi-2-3">Flash Ubuntu Core</a></p>
         
         <p>Package your applications as snaps for security and easy updates.</p>
-        <p><a href="">Install and use Snapcraft [link needed]</a></p>   
+        <p><a href="/snapcraft">Install and use Snapcraft</a></p>   
     </div> 
 </div>


### PR DESCRIPTION
1. Wiki link is the most maintained version of this content
2. Flashing steps are in the /core section
3. Linking to the local page as opposed to snapcraft.io, as the former has starter tutorials at a glance