### PR TITLE
Update sitemap

### DIFF
--- a/templates/includes/base.html
+++ b/templates/includes/base.html
@@ -87,6 +87,9 @@
 
 <div class="row">
   <div class="p-layout__wrap">
+    <div class="col-3 p-layout__sidebar">
+      {% include './base/sidebar.html' %}
+    </div>
     {% block content %}{% endblock %}
   </div>
 </div>

--- a/templates/includes/base/sidebar.html
+++ b/templates/includes/base/sidebar.html
@@ -1,5 +1,4 @@
 <nav class="p-sidebar-nav__nav{% if request.path == '/core' %} active{% endif %}">
-    <h2 class="p-sidebar-nav__title"><a class="sidebar-nav__title-link" href="/core">Core</a></h2>
     {% sidebar_nav %}
 </nav>
 

--- a/templates/includes/base/sidebar.html
+++ b/templates/includes/base/sidebar.html
@@ -1,6 +1,6 @@
 <nav class="p-sidebar-nav__nav{% if request.path == '/core' %} active{% endif %}">
     <h2 class="p-sidebar-nav__title"><a class="sidebar-nav__title-link" href="/core">Core</a></h2>
-    {% sidebar_nav 'core' %}
+    {% sidebar_nav %}
 </nav>
 
 <script>

--- a/templates/includes/components/sidebar_nav.html
+++ b/templates/includes/components/sidebar_nav.html
@@ -1,13 +1,28 @@
 <ul class="p-sidebar-nav__list">
-    {% for key, item in sitemap.children.items %}
-        <li class="p-sidebar-nav__group"><a href="{{ item.path }}" class="{{ item.class|default:"" }}">{{ item.title }}</a>
-        {% if item.children %}
-        <ul class="p-sidebar-nav__secondary">
-            {% for key, item in item.children.items %}
-                <li><a href="{{ item.path }}" class="{{ item.class|default:"" }}">{{ item.title }}</a></li>
-            {% endfor %}
-        </ul>
+    {% for item in items %}
+
+        {% if item.type == section %}
+
+            <li class="p-sidebar-nav__section">
+                {{ item.title }}
+                <ul class="">
+                    {% include 'includes/components/sidebar_nav.html' with item.children as items %}
+                </ul>
+            </li>
+
+        {% else %}
+
+            <li class="p-sidebar-nav__group"><a href="{{ item.path }}" class="{{ item.class|default:"" }}">{{ item.title }}</a>
+            {% if item.children %}
+            <ul class="p-sidebar-nav__secondary">
+                {% for item in item.children.items %}
+                    <li><a href="{{ item.path }}" class="{{ item.class|default:"" }}">{{ item.title }}</a></li>
+                {% endfor %}
+            </ul>
+            {% endif %}
+            </li>
+
         {% endif %}
-        </li>
+
     {% endfor %}
 </ul>

--- a/templates/includes/components/sidebar_nav.html
+++ b/templates/includes/components/sidebar_nav.html
@@ -1,28 +1,39 @@
 <ul class="p-sidebar-nav__list">
-    {% for item in items %}
+    {% for item in sitemap %}
 
-        {% if item.type == section %}
+        {% if item.type == 'back' %}
 
-            <li class="p-sidebar-nav__section">
-                {{ item.title }}
-                <ul class="">
-                    {% include 'includes/components/sidebar_nav.html' with item.children as items %}
-                </ul>
-            </li>
+            <li class="p-sidebar-nav__group">
+                <a href="{{ item.path }}">&larr; Back</a>
+
+        {% elif item.type == 'section' %}
+
+            <li class="p-sidebar-nav__group">
+                {% if item.title %}{{ item.title }}{% endif %}
 
         {% else %}
 
-            <li class="p-sidebar-nav__group"><a href="{{ item.path }}" class="{{ item.class|default:"" }}">{{ item.title }}</a>
-            {% if item.children %}
-            <ul class="p-sidebar-nav__secondary">
-                {% for item in item.children.items %}
-                    <li><a href="{{ item.path }}" class="{{ item.class|default:"" }}">{{ item.title }}</a></li>
-                {% endfor %}
-            </ul>
-            {% endif %}
-            </li>
+            <li>
+                <h2 class="p-sidebar-nav__title"><a href="{{ item.path }}" class="sidebar-nav__title-link {{ item.class|default:"" }}">{{ item.title }}</a></h2>
 
         {% endif %}
+
+                {% if item.children %}
+                    <ul class="p-sidebar-nav__primary">
+                        {% for item in item.children %}
+                            <li class="p-sidebar-nav__group"><a href="{{ item.path }}" class="{{ item.class|default:"" }}">{{ item.title }}</a>
+                            {% if item.children %}
+                            <ul class="p-sidebar-nav__secondary">
+                                {% for item in item.children %}
+                                    <li><a href="{{ item.path }}" class="{{ item.class|default:"" }}">{{ item.title }}</a></li>
+                                {% endfor %}
+                            </ul>
+                            {% endif %}
+                            </li>
+                        {% endfor %}
+                    </ul>
+                {% endif %}
+            </li>
 
     {% endfor %}
 </ul>

--- a/templates/includes/core.html
+++ b/templates/includes/core.html
@@ -1,10 +1,6 @@
 {% extends 'includes/base.html' %}
 
 {% block content %}
-  <div class="col-3 p-layout__sidebar">
-    {% include './base/sidebar.html' %}
-  </div>
-
   <div class="col-12 p-layout__main">
     <main id="main-content" class="p-layout__inner">
       {% block main_content %}{% endblock %}

--- a/templates/includes/navigation.yaml
+++ b/templates/includes/navigation.yaml
@@ -1,35 +1,36 @@
-root:
-  - Devices:
-    - Devices
-  - Topics:
-    - Development setup
-    - Ubuntu core
-    - Snapcraft
-    - Native apps
-    - Scops
-    - Web apps
-    - LXD containers
-    - MAAS
-  - Supporting content:
-    - Community resources
-    - Design
+-
+  _type: section
+  _items:
+    - devices
+    - target-platforms
 
-core:
-  get-started:
-    installation-medias:
-    raspberry-pi-2-3:
-    intel-joule:
-    dragonboard-410c:
-    intel-nuc:
-    artik-5-10:
-    kvm:
-    developer-setup:
-  tutorials:
-  examples:
-    hooks:
-    interfaces:
-    gadget-snaps:
-    assertions:
-  publish-and-distribute:
-  documentation:
-  troubleshooting:
+-
+  _title: Topics
+  _type: section
+  _items:
+    - core:
+      - get-started:
+        - installation-medias
+        - raspberry-pi-2-3
+        - intel-joule
+        - dragonboard-410c
+        - intel-nuc
+        - artik-5-10
+        - kvm
+        - developer-setup
+      - tutorials
+      - examples:
+        - hooks
+        - interfaces
+        - gadget-snaps
+        - assertions
+      - publish-and-distribute
+      - documentation
+      - troubleshooting
+    - snapcraft
+
+-
+  _title: Supporting content
+  _type: section
+  _items:
+  - community-resources

--- a/webapp/sitemap.py
+++ b/webapp/sitemap.py
@@ -1,7 +1,6 @@
 # Core modules
 import fnmatch
 import os
-from collections import OrderedDict
 from copy import deepcopy
 
 # Third party modules
@@ -10,33 +9,6 @@ from django.conf import settings
 
 # Local modules
 from webapp.lib.markdown import get_page_data
-
-
-# def dict_representer(dumper, data):
-#     return dumper.represent_dict(data.iteritems())
-#
-#
-# def dict_constructor(loader, node):
-#     return OrderedDict(loader.construct_pairs(node))
-#
-#
-# _mapping_tag = yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG
-# yaml.add_representer(OrderedDict, dict_representer)
-# yaml.add_constructor(_mapping_tag, dict_constructor)
-
-
-# def gen_dict_extract(key, var):
-#     if hasattr(var, 'iteritems'):
-#         for k, v in var.iteritems():
-#             if k == key:
-#                 yield v
-#             if isinstance(v, dict):
-#                 for result in gen_dict_extract(key, v):
-#                     yield result
-#             elif isinstance(v, list):
-#                 for d in v:
-#                     for result in gen_dict_extract(key, d):
-#                         yield result
 
 
 class Sitemap:
@@ -55,33 +27,56 @@ class Sitemap:
         parts = path.split('/')
         return parts
 
+    def _split_path_full(self, path):
+        """
+        This will take a path such as /1/2/3 and create:
+        [
+            '/1',
+            '/1/2',
+            '/1/2/3',
+        ]
+        """
+        path_list = []
+        path = path.strip('/')
+        parts = path.split('/')
+        current = ''
+        for part in parts:
+            current = '{current}/{new}'.format(current=current, new=part)
+            path_list.append(current)
+        return path_list
+
     def _find_navigation_item(self, nav_items, path):
         if not path:
             return
         if not isinstance(path, list):
-            path = self._split_path(path)
+            path = self._split_path_full(path)
 
-        for item in nav_items.iteritems():
+        found = None
+        for item in nav_items:
+            if not path:
+                break
             if 'path' in item and item['path'] == path[0]:
                 path.pop(0)
                 if not path:
-                    return item
-                if 'children' in item:
-                    self._find_navigation_item(item['children'], path)
-            elif 'path' not in item and 'children' in nav_items:
-                self._find_navigation_item(item['children'], path)
-        return False
+                    found = item
+                elif 'children' in item:
+                    found = self._find_navigation_item(item['children'], path)
+            elif 'path' not in item and 'children' in item:
+                found = self._find_navigation_item(item['children'], path)
+        return found
 
     def _set_active_navigation_items(self, nav_items, path):
         if not path:
             return
         if not isinstance(path, list):
-            path = self._split_path(path)
+            path = self._split_path_full(path)
 
-        item = self._find_navigation_item(nav_items, path[0])
+        last_path = path[-1]
+        current_path = path.pop(0)
+
+        item = self._find_navigation_item(nav_items, [current_path])
         if item:
-            path.pop(0)
-            if not path:
+            if last_path == item['path']:
                 item['active'] = True
                 item['class'] = 'active'
             else:
@@ -89,6 +84,52 @@ class Sitemap:
                 item['class'] = 'active-parent'
             if 'children' in item:
                 self._set_active_navigation_items(item['children'], path)
+
+    def _populate_navigation(self, config, sitemap):
+        """
+        Recurse through config and lookup keys from sitemap.
+        Put these keys in a new list of dictionaries. As it iterates through,
+        pass reference to the current nesting level of sorted/unsorted dicts.
+        """
+        nav_items = []
+        for config_item in config:
+            # Normalise nested string path items
+            if isinstance(config_item, dict) and '_type' not in config_item:
+                for k, v in config_item.items():
+                    config_item = {
+                        '_path': k,
+                        '_items': v,
+                    }
+
+            # Normalise simple string path items
+            if isinstance(config_item, str):
+                config_item = {'_path': config_item}
+
+            if config_item.get('_type') == 'section':
+                new = {
+                    'type': 'section',
+                    'title': config_item.get('_title', ''),
+                    'description': config_item.get('_description', ''),
+                }
+                new['children'] = self._populate_navigation(
+                    config_item['_items'],
+                    sitemap,
+                )
+                nav_items.append(new)
+            else:
+                key = config_item['_path']
+                new = {
+                    'path': sitemap[key]['path'],
+                    'title': config_item.get('_title', sitemap[key]['title']),
+                    'description': sitemap[key]['description'],
+                }
+                if '_items' in config_item:
+                    new['children'] = self._populate_navigation(
+                        config_item['_items'],
+                        sitemap[key]['children'],
+                    )
+                nav_items.append(new)
+        return nav_items
 
     def _build_metadata(self, path):
         if path.endswith('/'):
@@ -186,60 +227,22 @@ class Sitemap:
             with open(config_path, 'r') as navigation_file:
                 config = yaml.load(navigation_file)
 
-        unsorted_tree = self.get()
-        sorted_tree = []
+        sitemap = self.get()
+        sorted_tree = self._populate_navigation(config, sitemap)
 
-        def sort_tree(config, unsorted, sorting):
-            """
-            Recurse through config dictionary and lookup keys from sitemap.
-            Put these keys in a new OrderedDict. As it iterates through, pass
-            reference to the current nesting level of sorted/unsorted dicts.
-            """
-            unsorted = unsorted['children']
-            sorting = sorting['children']
-            for key, value in config.iteritems():
-                sorting[key] = OrderedDict({
-                    'path': unsorted[key]['path'],
-                    'title': unsorted[key]['title'],
-                    'description': unsorted[key]['description'],
-                    'children': [],
-                })
-                if isinstance(value, OrderedDict):
-                    sort_tree(value, unsorted[key], sorting[key])
-
-        sort_tree(config, unsorted_tree, sorted_tree)
-
-        # Determine current path and abstract section of sitemap
+        # Determine current path and only load correct section
         current_path = current_path.strip('/')
         root_path = None
         if current_path:
             root_path = current_path.split('/')[0]
-        if root_path:
-            sorted_tree = self._find_navigation_item(sorted_tree, root_path)
-            if root_path == current_path:
-                current_path = None
-            elif current_path.startswith(root_path):
-                current_path = current_path[len(root_path):]
-
-        # Mark current items as active if there is a path set
-        if current_path:
             self._set_active_navigation_items(sorted_tree, current_path)
-            # active_path_keys = self._split_path(current_path)
-            # final_key = active_path_keys.pop()
-            #
-            # current_tree_branch = sorted_tree['children']
-            # for key in active_path_keys:
-            #     current_tree_branch = current_tree_branch[key]
-            #     if current_tree_branch.get('children'):
-            #         current_tree_branch['active_parent'] = True
-            #         current_tree_branch['class'] = 'active-parent'
-            #         current_tree_branch = current_tree_branch['children']
-            #     else:
-            #         continue
-            #
-            # if final_key in current_tree_branch:
-            #     current_tree_branch[final_key]['active'] = True
-            #     current_tree_branch[final_key]['class'] = 'active'
+        if root_path:
+            sorted_tree = [self._find_navigation_item(sorted_tree, root_path)]
+            back_link = [{
+                'type': 'back',
+                'path': '/',
+            }]
+            sorted_tree = back_link + sorted_tree
 
         return sorted_tree
 

--- a/webapp/templatetags.py
+++ b/webapp/templatetags.py
@@ -98,14 +98,13 @@ def tutorial_cards(feed_config, limit=3):
 @register.inclusion_tag(
     'includes/components/sidebar_nav.html', takes_context=True
 )
-def sidebar_nav(context, root_path=None):
+def sidebar_nav(context):
     request = context['request']
-    site_tree = sitemap.build_navigation(
-        root_path=root_path,
+    nav_items = sitemap.build_navigation(
         current_path=request.path,
     )
     return {
-        'sitemap': site_tree,
+        'sitemap': nav_items,
     }
 
 


### PR DESCRIPTION
Update the sitemap to work with a simpler config, and work across the site.

The config now supports `_type: section` which show on the homepage to categorise parts of the menu, along with a "simpler" structure with less oddities.

## QA
The styling will be a bit odd but please check the output.
- The home page should have categories with the expected content
- The `/core` page should have the current page as a heading and the previous content again.
- `active-parent` and `active` classes should work nicely depending on the current page.