### PR TITLE
Collapse list padding/margin

### DIFF
--- a/templates/includes/components/grid_cards.html
+++ b/templates/includes/components/grid_cards.html
@@ -1,4 +1,4 @@
-<ul class="p-list grid-list u-clearfix col-12">
+<ul class="p-list grid-list u-clearfix col-12 u-no-padding--left u-no-margin--left">
     {% for page in pages %}
         <li class="col-6 grid-list__item{% if forloop.last %} last-item{% endif %}{% cycle ' odd' ' even' %}">
             {% if page.image %}<div class="grid-list__image-container"><img class="grid-list__image" alt="{{ page.title }} logo" src="{{ page.image }}"></div>{% endif %}

--- a/templates/includes/components/page_cards.html
+++ b/templates/includes/components/page_cards.html
@@ -1,4 +1,4 @@
-<ul class="p-list grid-list u-clearfix col-12">
+<ul class="p-list grid-list u-clearfix col-12 u-no-padding--left u-no-margin--left">
     {% for page in pages %}
         <li class="col-6 grid-list__item{% if forloop.last %} last-item{% endif %}{% cycle ' odd' ' even' %}">
             {% if page.image %}<div class="grid-list__image-container"><img class="grid-list__image" alt="{{ page.title }} logo" src="{{ page.image }}"></div>{% endif %}

--- a/templates/includes/components/tutorial_cards.html
+++ b/templates/includes/components/tutorial_cards.html
@@ -2,7 +2,7 @@
 
     <h2 class="cards__title">Latest tutorials</h2>
 
-    <ul class="p-list">
+    <ul class="p-list u-no-padding--left u-no-margin--left">
         {% for item in feed %}
             <li class="cards__item col-4">
                 <a class="cards__link" href="{{ item.link }}">

--- a/templates/includes/components/tutorials.html
+++ b/templates/includes/components/tutorials.html
@@ -1,5 +1,5 @@
 <div class="row u-no-padding--left">
-    <ul class="p-list tutorial-intro">
+    <ul class="p-list tutorial-intro u-no-padding--left u-no-margin--left">
         <li class="col-4 p-list__item tutorial-intro__item">
             <img class="tutorial-intro__image" src="https://assets.ubuntu.com/v1/e4f88585-pictogram_book02.svg" alt="" />
             <div>


### PR DESCRIPTION
## Done

Remove left margin and padding from generated content list components 

## QA

- Run ./run to get started
- Go to:
  - http://localhost:8015/core 
  - http://localhost:8015/core/get-started
  - http://localhost:8015//core/tutorials
- Check that the grid type lists and card type lists with the addition of the padding and margin collapse classes have no left padding or margin
