### PR TITLE
Update to latest docs theme

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "vanilla-docs-theme": "1.4.0",
+    "vanilla-docs-theme": "1.5.1",
     "node-sass": "4.5.2",
     "sass-lint": "1.10.2"
   },

--- a/static/sass/global.scss
+++ b/static/sass/global.scss
@@ -14,24 +14,12 @@
 
 // Patterns
 @import
-'vanilla-framework/scss/patterns_card',
 'patterns_divider';
-
-// Utilities
-@import
-'vanilla-framework/scss/utilities_margin-collapse',
-'vanilla-framework/scss/utilities_padding-collapse';
-
 
 // Include all the CSS
 
 // Patterns
-@include vf-p-card;
 @include theme-p-divider;
-
-// Utilities
-@include vf-u-margin-collapse;
-@include vf-u-padding-collapse;
 
 .nav-global-main {
   margin-top: 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1556,15 +1556,15 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
 
-vanilla-docs-theme@1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/vanilla-docs-theme/-/vanilla-docs-theme-1.4.0.tgz#9dbc89c4ab0bd3574bcd559687c134c75c543e64"
+vanilla-docs-theme@1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/vanilla-docs-theme/-/vanilla-docs-theme-1.5.1.tgz#c32a6696af0815905f05b8158d3ca8e16cbc3516"
   dependencies:
-    vanilla-framework "1.1.7"
+    vanilla-framework "1.2.0"
 
-vanilla-framework@1.1.7:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-1.1.7.tgz#87aecc939973fc70639e8de252a6067bc047be20"
+vanilla-framework@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-1.2.0.tgz#686cb37f6bece416e1972ba06340ed894df3fda7"
 
 verror@1.3.6:
   version "1.3.6"


### PR DESCRIPTION
## Done

Update vanilla docs theme to 1.5.1 
Remove imported vanilla-framework components

## QA

Run ./run to get started then have a look in package.json to make sure 1.5.1 is a dependency 