### PR TITLE
Remove custom pre styling

### DIFF
--- a/static/sass/global.scss
+++ b/static/sass/global.scss
@@ -361,21 +361,6 @@ a:link:hover {
   }
 }
 
-// override vanilla pre
-pre {
-  background-color: $color-light;
-  border: 1px solid $color-mid-light;
-  border-radius: 4px;
-  color: $color-dark;
-  font-family: Ubuntu Mono;
-  font-size: 1rem;
-  font-weight: 300;
-  overflow: hidden;
-  padding: .7rem 1rem;
-  position: relative;
-  width: 100%;
-}
-
 // tutorial-intro
 .tutorial-intro {
   &__item {


### PR DESCRIPTION
## Done

Remove custom pre styling

## QA

- Run ./run and head to http://localhost:8015/core/get-started/raspberry-pi-2-3
- Make sure it\s using the default vanilla framework styling

Fixes: https://github.com/canonical-websites/developer.ubuntu.com/issues/249