### PR TITLE
Allow empty path for markdown (ie, markdown homepage)

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -51,7 +51,7 @@ class MarkdownView(TemplateView):
                 return loader_instance
         raise Exception("Could not find MarkdownLoader")
 
-    def _find_template_source(self, path):
+    def _find_template_source(self, path=''):
         template_root = getattr(settings, 'TEMPLATE_FINDER_PATH', None)
         if template_root:
             path = ''.join([template_root, '/', path])
@@ -99,7 +99,7 @@ class MarkdownView(TemplateView):
         return context
 
     def get(self, request, *args, **kwargs):
-        request_path = self.kwargs['path']
+        request_path = self.kwargs.get('path')
         markdown, metadata = self._parse_markdown(request_path)
 
         context = self.get_context_data(


### PR DESCRIPTION
Creating a markdown url rule for '^$' was causing an error on an empty path.
This now allows a homepage to be markdown based

# QA

- Create a new url rule as above, and an index.md in `pages/`
- Check homepage loads
- Check other pages load nicely