### PR TITLE
Refactor global.scss

### DIFF
--- a/static/sass/_cards.scss
+++ b/static/sass/_cards.scss
@@ -1,5 +1,4 @@
 @charset 'utf-8';
-@import 'global-settings';
 
 .cards {
   clear: both;
@@ -11,6 +10,7 @@
   }
 
   & &__link {
+    background: none;
     transition: none;
 
     &:hover {
@@ -32,6 +32,7 @@
   & &__item {
     @media only screen and (max-width: $breakpoint-cards) {
       margin-left: 0;
+      padding-bottom: 0;
       width: 100%;
     }
 
@@ -89,13 +90,13 @@
     background: url('#{$assets-path}a88aa78c-card_background.png') no-repeat right bottom;
     background-size: cover;
     border-radius: 2px 2px 0 0;
-    color: $color-tutorial-card-header-font;
+    color: $color-x-light;
     min-height: 120px;
     padding: 10px 16px;
   }
 
   &__content {
-    border-bottom: 1px solid $color-tutorial-card-separator;
+    border-bottom: 1px solid $color-mid-light;
     color: $color-dark;
     font-weight: 300;
     margin: 16px;
@@ -136,7 +137,7 @@
   }
 
   &__date {
-    color: $color-tutorial-card-meta-font;
+    color: $color-mid-dark;
     font-weight: 300;
     margin-bottom: 15px;
     margin-top: 15px;
@@ -148,7 +149,7 @@
 
   &__tags {
     bottom: 0;
-    color: $color-tutorial-card-meta-font;
+    color: $color-mid-dark;
     font-weight: 300;
     margin-bottom: 10px;
     margin-top: 20px;

--- a/static/sass/_global-settings.scss
+++ b/static/sass/_global-settings.scss
@@ -1,17 +1,5 @@
 $site-max-width: auto;
-$breakpoint-cards: 1000px;
-$breakpoint-medium: 790px;
-$breakpoint-search: 982px;
-$button-width: 10px;
 $navigation-width: 256px;
 $color-translucent-black: rgba(0, 0, 0, .1);
-$color-brand: #e95420;
-$color-header-search-background: #ebebeb;
 $color-header-search-field-background: #c34113;
 $color-navigation-toggle-hover: $color-translucent-black;
-$color-search-result-border: #cdcdcd;
-$color-search-result-url: #888;
-$color-tutorial-card-header-font: #fff;
-$color-tutorial-card-meta-font: #666;
-$color-tutorial-card-separator: #e8e8e8;
-$asset-server-url: 'https://assets.ubuntu.com/v1/';

--- a/static/sass/_helpers.scss
+++ b/static/sass/_helpers.scss
@@ -1,3 +1,0 @@
-@mixin rounded-corners($radius: 4px 4px 4px 4px) {
-  border-radius: $radius;
-}

--- a/static/sass/_patterns_footer.scss
+++ b/static/sass/_patterns_footer.scss
@@ -1,0 +1,6 @@
+// site specific footer pattern styling
+@mixin developer-p-footer {
+  .p-footer {
+    border-color: $color-mid-light;
+  }
+}

--- a/static/sass/_patterns_global-nav.scss
+++ b/static/sass/_patterns_global-nav.scss
@@ -1,0 +1,17 @@
+// Override global nav styling
+@mixin developer-p-global-nav {
+
+  // global nav overrides
+  .nav-global-wrapper {
+    display: none;
+    width: $breakpoint-large !important;
+
+    @media only screen and (min-width: $breakpoint-medium) {
+      display: block;
+    }
+  }
+
+  .nav-global-main {
+    margin-top: 0;
+  }
+}

--- a/static/sass/_patterns_navigation.scss
+++ b/static/sass/_patterns_navigation.scss
@@ -1,0 +1,106 @@
+// Default navigation styling
+@mixin developer-p-navigation {
+  .p-navigation {
+    background: $color-brand;
+    border: $color-mid-light;
+    border-color: $color-mid-light;
+    color: $color-x-light;
+    padding: 0;
+
+    @media only screen and (min-width: $breakpoint-large) {
+      border-bottom: 0;
+    }
+
+    &__links {
+      background: darken($color-light, 3%);
+      float: right;
+      padding: 0;
+      width: auto;
+
+      @media only screen and (min-width: $breakpoint-medium) {
+        width: auto;
+      }
+
+      &::after {
+        background: lighten($color-brand, 12%);
+        content: '';
+        display: block;
+        height: 100%;
+        left: 0;
+        position: absolute;
+        top: 0;
+        width: 1px;
+      }
+    }
+
+    .p-navigation__link,
+    .p-navigation__link:visited,
+    .p-navigation__link:link {
+
+      @media only screen and (min-width: $breakpoint-medium) {
+        background: $color-brand;
+        border: 0;
+        color: $color-x-light;
+        display: block;
+        font-size: .875rem;
+        font-weight: bold;
+        overflow: hidden;
+        padding: 13px 14px;
+        width: auto;
+      }
+    }
+
+    .p-navigation__link--last-item {
+      border: 0;
+    }
+  }
+
+  .p-navigation .p-navigation__logo {
+    border: 0;
+    display: block;
+    margin: 6px 7px 6px 1rem;
+    padding-right: 5px;
+
+    @media only screen and (min-width: $breakpoint-medium) {
+      margin: 10px 7px 10px 1rem;
+    }
+
+    .p-navigation__link {
+      background: none;
+      border: 0;
+      color: $color-x-light;
+      font-size: 1.4375rem;
+      font-weight: normal;
+      padding: 0;
+      width: 100%;
+
+      &::before {
+        width: 0;
+      }
+
+      &:last-of-type {
+        border: 0;
+      }
+    }
+  }
+
+  .p-navigation .p-navigation__logo .p-navigation__link:hover {
+    background: none;
+    text-decoration: none;
+  }
+
+  .p-navigation .p-navigation__link:hover {
+    background: $color-light;
+    border-color: $color-mid-light;
+    text-decoration: none;
+
+    @media only screen and (min-width: $breakpoint-medium) {
+      background: lighten($color-brand, 6%);
+      border-color: darken($color-brand, 6%);
+    }
+  }
+
+  .p-navigation__links {
+    border-right: 0;
+  }
+}

--- a/static/sass/_search.scss
+++ b/static/sass/_search.scss
@@ -1,10 +1,10 @@
 .search-result {
-  border-bottom: 1px solid $color-search-result-border;
+  border-bottom: 1px solid $color-mid-light;
   margin-bottom: 1.5em;
 }
 
 .result-url {
-  color: $color-search-result-url;
+  color: $color-mid-dark;
   display: block;
 }
 
@@ -66,7 +66,7 @@
 }
 
 .header-search {
-  background-color: $color-header-search-background;
+  background-color: $color-mid-light;
   display: none;
   overflow: hidden;
   padding: 6px;
@@ -192,7 +192,7 @@
 
   &__field,
   .header-search__field {
-    background-color: $color-header-search-background;
+    background-color: $color-mid-light;
     border: 0;
     border-radius: 4px;
     box-shadow: none;

--- a/static/sass/_settings_breakpoints.scss
+++ b/static/sass/_settings_breakpoints.scss
@@ -1,0 +1,7 @@
+// site specific breakpoints
+
+$breakpoint-cards:      1000px;
+
+$breakpoint-medium:     790px;
+
+$breakpoint-search:     982px;

--- a/static/sass/_settings_colors.scss
+++ b/static/sass/_settings_colors.scss
@@ -1,0 +1,4 @@
+// site specific color settings
+
+$color-brand:       #e95420;
+$color-link:        $color-brand;

--- a/static/sass/_sidebar-nav.scss
+++ b/static/sass/_sidebar-nav.scss
@@ -1,5 +1,3 @@
-@import 'helpers';
-
 .p-layout__sidebar {
   background: $color-x-light;
   display: flex;
@@ -108,12 +106,12 @@
         position: absolute;
         right: $grid-gutter-width;
         top: $grid-gutter-width / 2;
-        width: $button-width;
+        width: $grid-gutter-width / 2;
       }
 
       &.collapsed {
         cursor: pointer;
-        padding-right: $grid-gutter-width + $button-width;
+        padding-right: $grid-gutter-width * 1.5;
 
         & > ul {
           display: none;

--- a/static/sass/global.scss
+++ b/static/sass/global.scss
@@ -3,19 +3,28 @@
 // import global settings
 @import 'global-settings';
 
-// import vanilla themes
+// Settings
+@import
+'settings_breakpoints',
+'settings_colors';
+
+// import vanilla theme
 @import 'vanilla-docs-theme/scss/theme';
 @include vanilla-docs-theme;
 
 @import
 'sidebar-nav',
-'helpers',
 'search';
+
+@import 'cards';
 
 // Patterns
 @import
 'patterns_cards',
-'patterns_divider';
+'patterns_divider',
+'patterns_global-nav',
+'patterns_footer',
+'patterns_navigation';
 
 
 // Include all the CSS
@@ -23,267 +32,14 @@
 // Patterns
 @include developer-p-cards;
 @include theme-p-divider;
-
-.nav-global-main {
-  margin-top: 0;
-}
-
-a,
-a:link,
-a:visited {
-  border-bottom-color: transparent;
-  color: $color-brand;
-}
+@include developer-p-footer;
+@include developer-p-global-nav;
+@include developer-p-navigation;
 
 a:hover,
 a:visited:hover,
 a:link:hover {
   border-bottom-color: currentcolor;
-}
-
-.p-link--external::after {
-  background-image: url('data:image/svg+xml,%3Csvg xmlns=\'http://www.w3.org/2000/svg\' width=\'14\' height=\'15\'%3E%3Cg fill=\'none\' fill-rule=\'evenodd\'%3E%3Cpath d=\'M-1-1h16v16H-1\'/%3E%3Cpath fill=\'%23e95420\' d=\'M4.867 1.313C.6 1.32.067 1.443.067 4.51v6.4c0 3.2.533 3.2 5.333 3.2h2.133c4.8 0 5.334 0 5.334-3.2v-1.6h-1.6v1.068c0 2.133 0 2.133-4.267 2.133H5.933c-4.266 0-4.266 0-4.266-2.132V5.044c0-1.93.034-2.112 3.2-2.13v-1.6z\'/%3E%3Cpath d=\'M-1-1h16v16H-1\'/%3E%3Cpath fill=\'%23e95420\' d=\'M6.435 2.16c.11-.446 7.113-2.196 7.448-1.86.335.334-1.416 7.335-1.863 7.447-.447.112-5.697-5.14-5.586-5.586z\'/%3E%3Cpath fill=\'%23e95420\' d=\'M9.032 3.38L4.705 7.708l1.767 1.767L10.8 5.148\'/%3E%3C/g%3E%3C/svg%3E');
-  background-position: top right;
-  background-repeat: no-repeat;
-  background-size: .7rem .7rem;
-  content: '';
-  display: inline-block;
-  height: .7rem;
-  margin: 0 0 0 4px;
-  position: relative;
-  right: 0;
-  top: -.3rem;
-  width: .7rem;
-}
-
-.theme__main {
-  border-color: $color-mid-light;
-  padding-top: 0;
-}
-
-.theme {
-  .p-navigation {
-    background: $color-brand;
-    border-bottom-color: $color-mid-light;
-    border-color: $color-mid-light;
-    color: $color-x-light;
-    padding: 0;
-
-    @media only screen and (min-width: $breakpoint-large) {
-      border-bottom: 0;
-    }
-
-    .p-navigation__toggle {
-      background-color: transparent;
-      background-repeat: no-repeat;
-      border: 0;
-      float: right;
-      height: 47px;
-      margin: 0;
-      overflow: hidden;
-      padding: 10px 10px 11px 10px;
-      width: 47px;
-
-
-      @media (min-width: $breakpoint-medium) {
-        display: none;
-      }
-    }
-
-    .p-navigation__toggle:hover {
-      background-color: $color-navigation-toggle-hover;
-    }
-
-    .p-navigation__icon {
-      height: 25px;
-      width: 25px;
-    }
-
-    &__links {
-      background: darken($color-light, 3%);
-      float: left;
-      padding: 0;
-      width: 100%;
-
-      @media only screen and (min-width: $breakpoint-medium) {
-        border-right: 1px solid lighten($color-brand, 12%);
-        width: auto;
-      }
-
-      &::after {
-        background: lighten($color-brand, 12%);
-        content: '';
-        display: block;
-        height: 100%;
-        left: 0;
-        position: absolute;
-        top: 0;
-        width: 1px;
-      }
-    }
-
-    .p-navigation__link,
-    .p-navigation__link:visited,
-    .p-navigation__link:link {
-      background: darken($color-light, 3%);
-      border-right: 1px solid $color-mid-light;
-      color: $color-dark;
-      float: left;
-      font-size: 1rem;
-      font-weight: normal;
-      padding: 9px 10px;
-      width: 50%;
-
-      @media only screen and (min-width: $breakpoint-medium) {
-        background: $color-brand;
-        border-bottom: 0;
-        border-left: 1px solid darken($color-brand, 6%);
-        border-right: 0;
-        color: $color-x-light;
-        font-size: .875rem;
-        font-weight: bold;
-        overflow: hidden;
-        padding: 13px 14px;
-        width: auto;
-
-        &:last-of-type {
-          border-right: 1px solid darken($color-brand, 6%);
-        }
-      }
-
-      @media only screen and (min-width: $breakpoint-medium) {
-        &::before {
-          background: lighten($color-brand, 12%);
-          content: ' ';
-          display: block;
-          height: 100%;
-          left: 0;
-          position: absolute;
-          top: 0;
-          width: 1px;
-        }
-      }
-    }
-
-    .p-navigation__link--last-item {
-      border-bottom: 0;
-    }
-  }
-
-  .p-navigation .p-navigation__logo {
-    border: 0;
-    margin: 6px 7px 6px 1rem;
-    padding-right: 5px;
-
-    @media only screen and (min-width: $breakpoint-medium) {
-      margin: 10px 7px 10px 1rem;
-    }
-
-    .p-navigation__link {
-      background: none;
-      border: 0;
-      color: $color-x-light;
-      font-size: 1.4375rem;
-      font-weight: normal;
-      padding: 0;
-      width: 100%;
-
-      &::before {
-        width: 0;
-      }
-
-      &:last-of-type {
-        border: 0;
-      }
-    }
-  }
-
-  .p-navigation .p-navigation__logo .p-navigation__link:hover {
-    background: none;
-    text-decoration: none;
-  }
-
-  .p-navigation .p-navigation__link:hover {
-    background: $color-light;
-    border-color: $color-mid-light;
-    text-decoration: none;
-
-    @media only screen and (min-width: $breakpoint-medium) {
-      background: lighten($color-brand, 6%);
-      border-color: darken($color-brand, 6%);
-    }
-  }
-
-  .p-navigation__links {
-    border-right: 0;
-  }
-}
-
-.theme__aside {
-  margin-top: -.5rem;
-  padding-top: 0;
-}
-
-.theme > .p-footer {
-  border-color: $color-mid-light;
-}
-
-.p-inline-list--tags {
-  margin-top: -1rem;
-
-  &__link {
-    color: $color-mid-dark !important;
-
-    &:link,
-    &:visited {
-      color: $color-mid-dark;
-      text-decoration: none;
-    }
-  }
-}
-
-.p-toc {
-  border-left-color: $color-mid-light;
-  padding-top: .75rem;
-
-  &__header {
-    color: $color-mid-dark;
-  }
-
-  &__item {
-    margin-bottom: .5rem;
-  }
-
-  &__link,
-  &__link:visited,
-  &__link:link {
-    color: $color-mid-dark;
-  }
-}
-
-// pagination
-.p-pagination {
-  display: flex;
-
-  &__item {
-    flex: 1;
-  }
-
-  &__link--previous {
-    margin-bottom: 1rem;
-  }
-
-  &__item--left {
-    text-align: right;
-  }
-
-  &__link {
-    &:link,
-    &:visited {
-      border: 1px solid $color-mid-dark;
-      color: inherit;
-    }
-  }
 }
 
 .grid-list {
@@ -358,16 +114,6 @@ a:link:hover {
   }
 }
 
-// global nav overrides
-.nav-global-wrapper {
-  display: none;
-  width: $breakpoint-large !important;
-
-  @media only screen and (min-width: $breakpoint-medium) {
-    display: block;
-  }
-}
-
 // tutorial-intro
 .tutorial-intro {
   &__item {
@@ -430,4 +176,3 @@ a:link:hover {
 }
 
 
-@import 'cards';


### PR DESCRIPTION
## Done

Refactor global.scss to split into modular files
Remove unused SASS

The following three ‘components’ still need to be stripped out, but I want to do them separately as I didn’t want this PR to get too large. 

- _cards.scss this is a separate file currently but needs to be refactored 
- .grid-list I’ve a branch for this to be replaced with the vanilla matrix pattern, need Yaili to approve first https://github.com/grahambancroft/developer.ubuntu.com/tree/v1-matrix
- .tutorial-intro needs to be renamed and refactored 

### Removed as isn’t needed

- static/sass/_helpers.scss
- .p-link--external::after
- .theme__main
- .p-inline-list--tags

## QA

- Run ./run to get started
- Go to http://0.0.0.0:8015/ and make sure the site still looks the same
- Check that the deleted SASS has been rehoused in its own file if it’s still needed