### PR TITLE
Add support for HTTP_X_FORWARDED_PROTO header

### DIFF
--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -25,6 +25,9 @@ SECRET_KEY = os.environ.get('SECRET_KEY', 'no_secret')
 ALLOWED_HOSTS = ['*']
 DEBUG = os.environ.get('DJANGO_DEBUG', 'false').lower() == 'true'
 
+USE_X_FORWARDED_HOST = True
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
 LANGUAGE_CODE = 'en-us'
 TIME_ZONE = 'UTC'
 USE_I18N = False


### PR DESCRIPTION
Read the HTTP_X_FORWARDED_PROTO header for Django to correctly set
redirects and internal references.

This will help with #271, once we have the correct headers being forwarded.