### PR TITLE
Add 'is_root' variable to navigation template

### DIFF
--- a/templates/includes/components/sidebar_nav.html
+++ b/templates/includes/components/sidebar_nav.html
@@ -1,4 +1,4 @@
-<ul class="p-sidebar-nav__list">
+<ul class="p-sidebar-nav__list {% if not is_root %}js-mobile-no-collapse{% endif %}">
     {% for item in sitemap %}
         {% if item.type == 'back' %}
 

--- a/templates/includes/components/sidebar_nav.html
+++ b/templates/includes/components/sidebar_nav.html
@@ -9,6 +9,7 @@
 
             <li class="p-sidebar-nav__group">
                 <h2 class="p-sidebar-nav__title"><a href="{{ item.path }}" class="sidebar-nav__title-link {{ item.class|default:"" }}">{{ item.title }}</a></h2>
+            </li>
 
         {% elif item.type == 'section' %}
 
@@ -18,22 +19,21 @@
                 <a href="{{ item.path }}" class="sidebar-nav__title-link {{ item.class|default:"" }}">{{ item.title }}</a>
 
         {% endif %}
-            {% if item.type == 'heading' %}</li>{% endif %}
-                {% if item.children %}
-                    <ul class="p-sidebar-nav__secondary">
-                        {% for item in item.children %}
-                            <li class="p-sidebar-nav__group"><a href="{{ item.path }}" class="{{ item.class|default:"" }}">{{ item.title }}</a>
-                                {% if item.children %}
-                                <ul class="p-sidebar-nav__tertiary">
-                                    {% for item in item.children %}
-                                        <li><a href="{{ item.path }}" class="{{ item.class|default:"" }}">{{ item.title }}</a></li>
-                                    {% endfor %}
-                                </ul>
-                                {% endif %}
-                            </li>
-                        {% endfor %}
-                    </ul>
-                {% endif %}
+            {% if item.children %}
+                {% if not item.type == 'heading' %}<ul class="p-sidebar-nav__secondary">{% endif %}
+                {% for item in item.children %}
+                    <li class="p-sidebar-nav__group"><a href="{{ item.path }}" class="{{ item.class|default:"" }}">{{ item.title }}</a>
+                        {% if item.children %}
+                        <ul class="p-sidebar-nav__tertiary">
+                            {% for item in item.children %}
+                                <li><a href="{{ item.path }}" class="{{ item.class|default:"" }}">{{ item.title }}</a></li>
+                            {% endfor %}
+                        </ul>
+                        {% endif %}
+                    </li>
+                {% endfor %}
+                {% if not item.type == 'heading' %}</ul>{% endif %}
+            {% endif %}
             {% if not item.type == 'heading' %}</li>{% endif %}
 
     {% endfor %}

--- a/webapp/templatetags.py
+++ b/webapp/templatetags.py
@@ -103,8 +103,16 @@ def sidebar_nav(context):
     nav_items = sitemap.build_navigation(
         current_path=request.path,
     )
+    is_root = True
+    if nav_items:
+        first_item = nav_items[0]
+        is_root = not (
+            not first_item['type'] == 'back' and
+            not first_item['type'] == 'heading'
+        )
     return {
         'sitemap': nav_items,
+        'is_root': is_root,
     }
 
 


### PR DESCRIPTION
Check if navigation is in root, if not, set a no collapse class. Rename as needed.
Also, remove ul directly inside a ul element.

cc: @grahambancroft 