### PR TITLE
Use Tutorials published time with fallback to updated

### DIFF
--- a/templates/includes/components/tutorial_cards.html
+++ b/templates/includes/components/tutorial_cards.html
@@ -13,7 +13,7 @@
                         </div>
                         <div class="tutorial-card__content">
                             <p class="tutorial-card__date">
-                                <time pubdate datetime="{{ item.updated }}">{{ item.updated_datetime|date:"j F Y" }}</time>
+                                <time pubdate datetime="{{ item.published }}">{{ item.published_datetime|date:"j F Y" }}</time>
                             </p>
                             <p class="tutorial-card__summary">{{ item.summary|truncate_chars:195 }}</p>
                         </div>

--- a/webapp/templatetags.py
+++ b/webapp/templatetags.py
@@ -88,6 +88,8 @@ def tutorial_cards(feed_config, limit=3):
     feed_data = feed_data[:limit]
 
     for item in feed_data:
+        item['published'] = item.get('published', item['updated'])
+        item['published_datetime'] = dateutil.parser.parse(item['published'])
         item['updated_datetime'] = dateutil.parser.parse(item['updated'])
 
     return {


### PR DESCRIPTION
We are changing to use published time for Tutorials and not updated.

This will now use the published time but with a fallback to updated time in case it is not set in the API.

## QA

- ./run
- Head over to http://localhost:8015/core/tutorials
- Check the dates show with no errors