### PR TITLE
Hotfix some issues

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1,2 +1,5 @@
+en: '/'
+en(/(?P<path>.*))?: /{path}
+
 # Remove trailing slash, .html, or index from URLs
 (?P<path>.*)?(/|.html|index): /{path}

--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -25,9 +25,6 @@ SECRET_KEY = os.environ.get('SECRET_KEY', 'no_secret')
 ALLOWED_HOSTS = ['*']
 DEBUG = os.environ.get('DJANGO_DEBUG', 'false').lower() == 'true'
 
-USE_X_FORWARDED_HOST = True
-SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
-
 LANGUAGE_CODE = 'en-us'
 TIME_ZONE = 'UTC'
 USE_I18N = False

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -7,7 +7,6 @@ from django.http import (
     HttpResponseServerError,
 )
 from django.template import (
-    Context,
     loader,
     RequestContext,
     Template,
@@ -23,13 +22,12 @@ from webapp.loaders import MarkdownLoader
 
 def custom_404(request):
     t = loader.get_template('error/404.html')
-    context = RequestContext(request, {'request_path': request.path})
-    return HttpResponseNotFound(t.render(context))
+    return HttpResponseNotFound(t.render({'request_path': request.path}))
 
 
 def custom_500(request):
     t = loader.get_template('error/500.html')
-    return HttpResponseServerError(t.render(Context({})))
+    return HttpResponseServerError(t.render({'request_path': request.path}))
 
 
 class MarkdownView(TemplateView):


### PR DESCRIPTION
Forwarded header settings caused errors. GONE.
Context broke views in Django 1.11. GONE.
Need redirect. ADDED.