### PR TITLE
Correctly load nav on error pages

### DIFF
--- a/webapp/sitemap.py
+++ b/webapp/sitemap.py
@@ -315,16 +315,17 @@ class Sitemap:
             self._set_active_navigation_items(sorted_tree, current_path)
         if root_path_key:
             root_node = self._find_navigation_item(sorted_tree, root_path_key)
-            if root_node.get('children'):
-                sorted_tree = [root_node]
-                back_link = [{
-                    'type': 'back',
-                    'path': '/',
-                }]
-                sorted_tree = back_link + sorted_tree
-            elif root_node.get('type') == 'heading':
-                root_node['type'] = None
-
+            if root_node:
+                if root_node.get('children'):
+                    sorted_tree = [root_node]
+                    back_link = [{
+                        'type': 'back',
+                        'path': '/',
+                    }]
+                    sorted_tree = back_link + sorted_tree
+                elif root_node.get('type') == 'heading':
+                    print('2')
+                    root_node['type'] = None
         return sorted_tree
 
 

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -22,12 +22,18 @@ from webapp.loaders import MarkdownLoader
 
 def custom_404(request):
     t = loader.get_template('error/404.html')
-    return HttpResponseNotFound(t.render({'request_path': request.path}))
+    return HttpResponseNotFound(t.render({
+        'request': request,
+        'request_path': request.path
+    }))
 
 
 def custom_500(request):
     t = loader.get_template('error/500.html')
-    return HttpResponseServerError(t.render({'request_path': request.path}))
+    return HttpResponseServerError(t.render({
+        'request': request,
+        'request_path': request.path
+    }))
 
 
 class MarkdownView(TemplateView):


### PR DESCRIPTION
Pass the request object to the templates, and make sure to return the default nav if the page does not exist in the tree.

This allows the nav to show on PR #295.