### PR TITLE
/desktop no longer has a home

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -8,5 +8,4 @@
 (en/|zh-cn/)?phone/devices/?: https://docs.ubuntu.com/phone/en/devices/index
 (en/|zh-cn/)?snappy/start/?: /core/get-started
 (en/|zh-cn/)?phone(?P<path>.*)/?: https://docs.ubuntu.com/phone/en{path}
-(en/|zh-cn/)?desktop/?: https://www.ubuntu.com/desktop
 (en/|zh-cn/)?snappy/?: /core


### PR DESCRIPTION
Make `/desktop` 404, as it doesn't have a new home.

QA
--

`./run` and go to http://localhost:8015/desktop, see a 404.