### PR TITLE
Redirect /api to phone docs

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -8,4 +8,5 @@
 (en/|zh-cn/)?phone/devices/?: https://docs.ubuntu.com/phone/en/devices/index
 (en/|zh-cn/)?snappy/start/?: /core/get-started
 (en/|zh-cn/)?phone(?P<path>.*)/?: https://docs.ubuntu.com/phone/en{path}
+(en/|zh-cn/)?api/?: https://docs.ubuntu.com/phone/en/
 (en/|zh-cn/)?snappy/?: /core


### PR DESCRIPTION
Fixes #292

QA
--

`./run` and go to <http://localhost:8015/api>. You should find yourself looking at the phone docs.