### PR TITLE
Add redirect from /start/

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -9,4 +9,5 @@
 (en/|zh-cn/)?snappy/start/?: /core/get-started
 (en/|zh-cn/)?phone(?P<path>.*)/?: https://docs.ubuntu.com/phone/en{path}
 (en/|zh-cn/)?api/?: https://docs.ubuntu.com/phone/en/
+(en/|zh-cn/)?start/?: https://docs.ubuntu.com/phone/en/
 (en/|zh-cn/)?snappy/?: /core


### PR DESCRIPTION
## Done
Added a redirect from /start/ to https://docs.ubuntu.com/phone/en/

## QA
- Run `./run`
- Go to http://0.0.0.0:8015/start/
- See that it redirects