### PR TITLE
Add snappy redirect

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -12,3 +12,4 @@
 (en/|zh-cn/)?start/?: https://docs.ubuntu.com/phone/en/
 (en/|zh-cn/)?snappy/?: /core
 (en/|zh-cn/)?snappy/guides/security-whitepaper/?: /core/documentation
+snappy/build-apps : /snapcraft


### PR DESCRIPTION
## Done

Add snappy redirect

## QA

./run then go to http://0.0.0.0:8015/snappy/build-apps and you should be redirected to  http://0.0.0.0:8015/snapcraft

## Issue/card

Fixes #299

