### PR TITLE
Use latest canonicalwebteam.get-feeds

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-canonicalwebteam.get-feeds==0.1.5
+canonicalwebteam.get-feeds==0.1.7
 Django==1.11.1
 dj-static==0.0.6
 django-versioned-static-url==0.8


### PR DESCRIPTION
For best error handling.

QA
--

`./run` and check feeds still load