### PR TITLE
Fixed tutorial feeds making incorrect api calls

### DIFF
--- a/templates/pages/core/tutorials.md
+++ b/templates/pages/core/tutorials.md
@@ -4,8 +4,7 @@ description: A series of tutorials, step by step practical guides to help you ac
 page_type: modular
 tutorial_feed:
     categories:
-        - snap
-        - snapcraft
+        - iot
 ---
 
 # Tutorials

--- a/templates/pages/snapcraft/index.md
+++ b/templates/pages/snapcraft/index.md
@@ -1,4 +1,4 @@
-----
+---
 title: Snapcraft
 description: Snapcraft summary page
 page_type: modular
@@ -6,8 +6,8 @@ insights_feed:
     tag: snapcraft
 tutorial_feed:
     categories:
-        - snapcraft
-----
+        - packaging
+---
 
 # Snapcraft
 


### PR DESCRIPTION
## Done

- Changed the category calls to match with the tutorials.ubuntu.com api in /snapcraft and /core/tutorials


## QA

- Check that relevant tutorials are loaded in for /snapcraft and /core/tutorials


## Issue / Card

Fixes #317 