### PR TITLE
Fixed encoding errors on insights cards

### DIFF
--- a/templates/includes/components/feed_cards.html
+++ b/templates/includes/components/feed_cards.html
@@ -9,9 +9,9 @@
         <li class="cards__item col-4">
           <a class="cards__link" href="{{ item.link }}">
             <div class="p-card--highlighted">
-              <h3 class="p-card--highlighted__title">{{ item.title }}</h3>
+              <h3 class="p-card--highlighted__title">{{ item.title|safe }}</h3>
               <p class="p-card--highlighted__date"><time pubdate datetime="{{ item.updated }}">{{ item.updated_datetime|date:"j F Y" }}</time></p>
-              <p class="p-card--highlighted__content">{{ item.description|truncate_chars:80 }}</p>
+              <p class="p-card--highlighted__content">{{ item.description|truncatechars:80|safe }}</p>
               <p class="note p-card--highlighted__source">Ubuntu Insights</p>
             </div>
           </a>


### PR DESCRIPTION
## Done

- Fixed encoding errors on insights cards


## QA

- Navigate to /snapcraft. If the 18 Oct 2017 article is still recent it should show up in the 'Latest News' section. Make sure the content contains no encoding errors for things like apostrophes, dashes etc


## Issue / Card

Fixes #320 