### PR TITLE
Fixed errant bullet points on small-screen grids/lists

### DIFF
--- a/static/sass/global.scss
+++ b/static/sass/global.scss
@@ -51,6 +51,8 @@ a:link:hover {
 .grid-list {
   $grid-border-style: 1px dotted $color-mid-light;
 
+  list-style-type: none;
+
   @media only screen and (min-width: $breakpoint-medium) {
     display: flex;
     flex-wrap: wrap;
@@ -182,5 +184,3 @@ a:link:hover {
 .is-visible {
   display: block;
 }
-
-


### PR DESCRIPTION
## Done

- Removed bullet points from grids/lists that had them as the default list style


## QA

- Navigate to /core/get-started and resize to mobile. Check that there are no bullet points to the left of each platform.


## Issue / Card

Fixes #321 