### PR TITLE
Truncate card titles to a max of 3 lines

### DIFF
--- a/templates/includes/components/feed_cards.html
+++ b/templates/includes/components/feed_cards.html
@@ -7,9 +7,9 @@
     <ul class="p-list u-no-padding--left u-no-margin--left">
       {% for item in feed %}
         <li class="cards__item col-4">
-          <a class="cards__link" href="{{ item.link }}">
+          <a class="cards__link" href="{{ item.link }}" title="{{ item.title }}">
             <div class="p-card--highlighted">
-              <h3 class="p-card--highlighted__title">{{ item.title|safe }}</h3>
+              <h3 class="p-card--highlighted__title">{{ item.title|truncatechars:50|safe }}</h3>
               <p class="p-card--highlighted__date"><time pubdate datetime="{{ item.updated }}">{{ item.updated_datetime|date:"j F Y" }}</time></p>
               <p class="p-card--highlighted__content">{{ item.description|truncatechars:80|safe }}</p>
               <p class="note p-card--highlighted__source">Ubuntu Insights</p>


### PR DESCRIPTION
## Done
Set the character length of the titles to 50. Added the card title to the title of the link so on hover the user can see the whole title.

## QA
- Run `./run` _if you get an error, try running `bower install` then `./run` again_
- Go to http://0.0.0.0:8015/
- Check that the latest news cards titles truncate and do not go over 3 lines.

Fixes https://github.com/canonical-websites/developer.ubuntu.com/issues/199

## Screenshot
![screenshot-2017-12-20 welcome developer](https://user-images.githubusercontent.com/1413534/34202469-bf512554-e56f-11e7-9f8a-947c583dc162.png)
