### PR TITLE
Add raspi2 redirect

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -14,6 +14,7 @@
 (en/|zh-cn/)?snappy/guides/security-whitepaper/?: /core/documentation
 (en/|zh-cn/)?/snappy/guides/mir-snaps/?: /core/examples/snaps-on-mir
 (en/|zh-cn/)?/snappy/build-apps/? : /snapcraft
+(en/|zh-cn/)?/snappy/start/raspberry-pi-2 : /core/get-started/raspberry-pi-2-3
 
 # Boards
 intel/? : /target-platforms/boards#intel


### PR DESCRIPTION
Adding a missing explicit redirect to the /core/get-started/raspberry-pi-2-3 page as we are still seeing some hits on the old address.