### PR TITLE
Remove unneeded slashes from redirects

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -12,9 +12,9 @@
 (en/|zh-cn/)?start/?: https://docs.ubuntu.com/phone/en/
 (en/|zh-cn/)?snappy/?: /core
 (en/|zh-cn/)?snappy/guides/security-whitepaper/?: /core/documentation
-(en/|zh-cn/)?/snappy/guides/mir-snaps/?: /core/examples/snaps-on-mir
-(en/|zh-cn/)?/snappy/build-apps/? : /snapcraft
-(en/|zh-cn/)?/snappy/start/raspberry-pi-2 : /core/get-started/raspberry-pi-2-3
+(en/|zh-cn/)?snappy/guides/mir-snaps/?: /core/examples/snaps-on-mir
+(en/|zh-cn/)?snappy/build-apps/? : /snapcraft
+(en/|zh-cn/)?snappy/start/raspberry-pi-2 : /core/get-started/raspberry-pi-2-3
 
 # Boards
 intel/? : /target-platforms/boards#intel


### PR DESCRIPTION
Remove extra slashes in the redirects file which is breaking the redirects

## QA

Check http://developer.ubuntu.com-pr-340.run.demo.haus/snappy/build-apps
redirects to http://developer.ubuntu.com-pr-340.run.demo.haus/snapcraft