### PR TITLE
Update global nav to v0.2.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,6 +21,6 @@
     "static/components"
   ],
   "dependencies": {
-    "canonical-global-nav": "~0.1.8"
+    "canonical-global-nav": "~0.2.0"
   }
 }

--- a/static/sass/global.scss
+++ b/static/sass/global.scss
@@ -42,6 +42,11 @@
 @include developer-p-layout;
 @include developer-p-navigation;
 
+
+html {
+  overflow-x: hidden !important;
+}
+
 a:hover,
 a:visited:hover,
 a:link:hover {


### PR DESCRIPTION
## Done
Update the global nav and fix horizontal overflow.

## QA
- Pull code
- Run `./run`
- Go to the hompage and check at no screen size there is no horizontal scrolling 

## Details
Fixes https://github.com/canonical-websites/developer.ubuntu.com/issues/169