### PR TITLE
Add DEVEL to .env variables

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,3 @@
 PORT=8015
+DEVEL=true
 DJANGO_DEBUG=true


### PR DESCRIPTION
Add `DEVEL=true` to the environment variables.
When this is set, Talisker adds pretty colours to the terminal logs.

## QA

Start `./run` and look at the logs