### PR TITLE
Entrypoint for talisker gevent workers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,15 @@
-FROM ubuntu:xenial
+FROM ubuntu:bionic
+
+# Set up environment
+ENV LANG C.UTF-8
+WORKDIR /srv
 
 # System dependencies
 RUN apt-get update && apt-get install --yes python3-pip
 
-# Python dependencies
-ENV LANG C.UTF-8
-RUN pip3 install --upgrade pip
-
 # Import code, install code dependencies
-WORKDIR /srv
 ADD . .
-RUN pip install -r requirements.txt
+RUN pip3 install -r requirements.txt
 
 # Set git commit ID
 ARG COMMIT_ID
@@ -18,6 +17,6 @@ RUN test -n "${COMMIT_ID}"
 RUN echo "${COMMIT_ID}" > version-info.txt
 
 # Setup commands to run server
-ENTRYPOINT ["talisker.gunicorn", "webapp.wsgi", "--access-logfile", "-", "--error-logfile", "-", "--bind"]
+ENTRYPOINT ["./entrypoint"]
 CMD ["0.0.0.0:80"]
 

--- a/entrypoint
+++ b/entrypoint
@@ -1,0 +1,6 @@
+#! /usr/bin/env bash
+
+set -e
+
+talisker.gunicorn.gevent webapp.wsgi --reload --log-level debug --timeout 9999 --access-logfile - --workers 3 --worker-class gevent --error-logfile - --bind $1
+

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "node-sass --include-path node_modules static/sass --output static/css && postcss --use autoprefixer --replace 'static/css/**/*.css' && postcss --use cssnano --dir static/minified 'static/css/**/*.css'",
     "watch": "watch -p 'static/sass/**/*.scss' -c 'yarn run build'",
-    "serve": "talisker.gunicorn webapp.wsgi --reload --timeout 9999 --access-logfile - --error-logfile - --bind 0.0.0.0:${PORT}",
+    "serve": "./entrypoint 0.0.0.0:${PORT}",
     "test": "sass-lint static/**/*.scss --verbose --no-exit",
     "clean": "rm -rf node_modules yarn-error.log css static/css *.log *.sqlite _site/ build/ .jekyll-metadata .bundle"
   },

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,8 @@ django-asset-server-url==0.1
 django-template-finder-view==0.3
 django-unslashed==0.3.0
 django-yaml-redirects==0.5.4
-talisker==0.9.6
+talisker==0.9.13
+gunicorn[gevent]
 feedparser==5.2.1
 lockfile==0.12.2
 markdown==2.6.7


### PR DESCRIPTION
Fixes https://github.com/ubuntudesign/base-squad/issues/104

QA
--

``` bash
./run
```

See that it mentions "Booting worker" 3 times. Go to http://localhost:8015, check it works. Then:

``` bash
docker build --tag dev --build-arg COMMIT_ID=`git rev-parse HEAD` .
docker run -ti -p 8099:80 dev
```

See that it mentions "Booting worker" 3 times. Go to http://localhost:8099, check it also works.

Also, check the `X-VCS-Revision` shows correctly:

``` bash
$ curl -Is localhost:8099 | grep VCS
X-VCS-Revision: {commit_hash}
```