### PR TITLE
Add net-tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV LANG C.UTF-8
 WORKDIR /srv
 
 # System dependencies
-RUN apt-get update && apt-get install --yes python3-pip
+RUN apt-get update && apt-get install --yes python3-pip net-tools
 
 # Import code, install code dependencies
 ADD . .

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,8 @@ django-asset-server-url==0.1
 django-template-finder-view==0.3
 django-unslashed==0.3.0
 django-yaml-redirects==0.5.4
-talisker==0.9.13
+statsd<3.3.0
+talisker==0.9.14
 gunicorn[gevent]
 feedparser==5.2.1
 lockfile==0.12.2


### PR DESCRIPTION
This is so we can use `netstat` in a `livenessProbe` to check a process is running on port 80.