### PR TITLE
Upgrade talisker

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ django-unslashed==0.3.0
 django-yaml-redirects==0.5.4
 statsd<3.3.0
 prometheus_client==0.3.1
-talisker==0.9.14
+talisker==0.9.16
 gunicorn[gevent]
 feedparser==5.2.1
 lockfile==0.12.2


### PR DESCRIPTION
The latest version of talisker has important fixes for prometheus.

QA
--

`./run`, check the site still works.

``` bash
docker build --tag developer.ubuntu.com --build-arg COMMIT_ID=`git rev-parse HEAD` .
docker run -ti -p 8997:80 developer.ubuntu.com
```

Go to http://127.0.0.1:8997, check the site works this way too.