### PR TITLE
Upgrade to Django 1.11.16

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 canonicalwebteam.get-feeds==0.1.7
-Django==1.11.1
+Django==1.11.16
 dj-static==0.0.6
 django-versioned-static-url==0.8
 django-static-root-finder==0.1


### PR DESCRIPTION
Which isn't vulnerable to https://nvd.nist.gov/vuln/detail/CVE-2018-14574

QA
--

`./run`, go to http://0.0.0.0:8015, click around