### PR TITLE
Updated link to snapcraft.io snaps dashboard

### DIFF
--- a/templates/includes/base/header.html
+++ b/templates/includes/base/header.html
@@ -14,7 +14,7 @@
       <a href="#main-content">Jump to main content</a>
     </span>
     <ul class="p-navigation__links">
-      <li class="p-navigation__link"><a class="p-link--external p-link--strong" href="https://dashboard.snapcraft.io/dev/snaps/">snapcraft.io dashboard</a></li>
+      <li class="p-navigation__link"><a class="p-link--external p-link--strong" href="https://snapcraft.io/snaps/">snapcraft.io dashboard</a></li>
     </ul>
   </nav>
 </header>

--- a/templates/includes/base/header.html
+++ b/templates/includes/base/header.html
@@ -14,7 +14,7 @@
       <a href="#main-content">Jump to main content</a>
     </span>
     <ul class="p-navigation__links">
-      <li class="p-navigation__link"><a class="p-link--external p-link--strong" href="https://snapcraft.io/snaps/">snapcraft.io dashboard</a></li>
+      <li class="p-navigation__link"><a class="p-link--external p-link--strong" href="https://snapcraft.io/snaps/">View your snaps in snapcraft.io</a></li>
     </ul>
   </nav>
 </header>


### PR DESCRIPTION
## QA

1. Pull the branch or open demo service
2. Notice the top right header link `snapcraft.io dashboard (external)` links to https://snapcraft.io/snaps

