### PR TITLE
Renovate: Group minor dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,13 @@
     {
       "depTypeList": ["devDependencies"],
       "extends": [":automergeMinor"]
+    },
+    {
+      "packagePatterns": ["*"],
+      "minor": {
+        "groupName": "all non-major dependencies",
+        "groupSlug": "all-minor-patch"
+      }
     }
   ]
 }


### PR DESCRIPTION
Update renovate config to match docs.snapcraft.io.
See rationale here: https://github.com/canonical-websites/docs.snapcraft.io/pull/111/files