### PR TITLE
Renovate config: Use django 1.x

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,11 @@
       "allowedVersions": "<3"
     },
     {
+      "managers": ["pip"],
+      "packageNames": ["django"],
+      "allowedVersions": "<2"
+    },
+    {
       "depTypeList": ["devDependencies"],
       "extends": [":automergeMinor"]
     },

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 canonicalwebteam.get-feeds==0.2.4
-Django==1.11.18
+django==1.11.18
 dj-static==0.0.6
 django-versioned-static-url==0.8
 django-static-root-finder==0.3.1


### PR DESCRIPTION
Tell Renovate not to upgrade to Django 2 - it's not worth it for
this site, which will be decommissioned before too long.